### PR TITLE
Add archlinux support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/knqyf263/vuln-list/
 $ vuln-list-update -h
 Usage of vuln-list-update:
   -target string
-        update target (nvd, alpine, redhat, debian, ubuntu)
+        update target (nvd, alpine, redhat, debian, ubuntu, archlinux)
   -years string
         update years (only redhat)
 ```

--- a/archlinux/archlinux.go
+++ b/archlinux/archlinux.go
@@ -1,0 +1,104 @@
+package archlinux
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/knqyf263/vuln-list-update/utils"
+	"golang.org/x/xerrors"
+)
+
+const (
+	listURL      = "https://security.archlinux.org/issues/all.json"
+	advisoryURL  = "https://security.archlinux.org/%s/generate/raw"
+	baseURL      = "https://security.archlinux.org/%s.json"
+	archlinuxDir = "archlinux"
+
+	concurrency = 10
+	wait        = 1
+	retry       = 10
+)
+
+func Update() error {
+	log.Println("Fetching Archlinux data...")
+	issues, err := listAllArchlinuxIssues(0)
+	if err != nil {
+		return xerrors.Errorf("error in list Archlinux cves: %w", err)
+	}
+
+	urlsMap := make(map[string]struct{})
+	for _, issue := range issues {
+		for _, cveId := range issue.Issues {
+			urlsMap[fmt.Sprintf(baseURL, cveId)] = struct{}{}
+		}
+	}
+	var urls []string
+	for url := range urlsMap {
+		urls = append(urls, url)
+	}
+
+	cves := map[string]ArchlinuxCve{}
+	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry)
+	for _, cveJSON := range cveJSONs {
+		var cve ArchlinuxCve
+		if err = json.Unmarshal(cveJSON, &cve); err != nil {
+			log.Printf("json decode error: %s", err)
+			continue
+		}
+		cves[cve.Name] = cve
+	}
+
+	var avis []ArchlinuxVulnInfo
+	for _, issue := range issues {
+		for _, pkg := range issue.Packages {
+			for _, cveId := range issue.Issues {
+				avi := ArchlinuxVulnInfo{
+					Package:     pkg,
+					Status:      issue.Status,
+					Affected:    issue.Affected,
+					Fixed:       issue.Fixed,
+					Ticket:      issue.Ticket,
+					Name:        cves[cveId].Name,
+					Groups:      cves[cveId].Groups,
+					Type:        cves[cveId].Type,
+					Severity:    cves[cveId].Severity,
+					Vector:      cves[cveId].Vector,
+					Description: cves[cveId].Description,
+					Advisories:  cves[cveId].Advisories,
+					References:  cves[cveId].References,
+					Notes:       cves[cveId].Notes,
+				}
+				avis = append(avis, avi)
+			}
+		}
+	}
+
+	for _, avi := range avis {
+		dir := filepath.Join(utils.VulnListDir(), archlinuxDir, avi.Package)
+		os.MkdirAll(dir, os.ModePerm)
+		filePath := filepath.Join(dir, fmt.Sprintf("%s.json", avi.Name))
+		if err = utils.Write(filePath, avi); err != nil {
+			return xerrors.Errorf("failed to write Archlinux CVE details: %w", err)
+		}
+	}
+	return nil
+}
+
+func listAllArchlinuxIssues(wait int) (issues []ArchlinuxIssue, err error) {
+	body, err := utils.FetchURL(listURL, "", retry)
+	if err != nil {
+		return issues, xerrors.Errorf("failed to fetch ArchLinux issues list: url: %s, err: %w", listURL, err)
+	}
+	var issueList []ArchlinuxIssue
+	if err = json.Unmarshal(body, &issueList); err != nil {
+		return nil, err
+	}
+	issues = append(issues, issueList...)
+	time.Sleep(time.Duration(wait) * time.Second)
+
+	return issues, nil
+}

--- a/archlinux/types.go
+++ b/archlinux/types.go
@@ -1,0 +1,44 @@
+package archlinux
+
+type ArchlinuxIssue struct {
+	Packages []string `json:"packages"`
+	Issues   []string `json:"issues"`
+
+	Status   string      `json:"status"`
+	Affected string      `json:"affected"`
+	Fixed    string      `json:"fixed"`
+	Ticket   interface{} `json:"ticket"`
+}
+
+type ArchlinuxCve struct {
+	Name        string      `json:"name"`
+	Groups      []string    `json:"groups"`
+	Type        string      `json:"type"`
+	Severity    string      `json:"severity"`
+	Vector      string      `json:"vector"`
+	Description string      `json:"description"`
+	Advisories  []string    `json:"advisories"`
+	References  []string    `json:"references"`
+	Notes       interface{} `json:"notes"`
+}
+
+type ArchlinuxVulnInfo struct {
+	Package string `json:"package"`
+
+	// ArchlinuxIssue
+	Status   string      `json:"status"`
+	Affected string      `json:"affected"`
+	Fixed    string      `json:"fixed"`
+	Ticket   interface{} `json:"ticket"`
+
+	// ArchlinuxCve
+	Name        string      `json:"name"`
+	Groups      []string    `json:"groups"`
+	Type        string      `json:"type"`
+	Severity    string      `json:"severity"`
+	Vector      string      `json:"vector"`
+	Description string      `json:"description"`
+	Advisories  []string    `json:"advisories"`
+	References  []string    `json:"references"`
+	Notes       interface{} `json:"notes"`
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/knqyf263/vuln-list-update/alpine"
-
+	"github.com/knqyf263/vuln-list-update/archlinux"
 	"github.com/knqyf263/vuln-list-update/debian"
 	"github.com/knqyf263/vuln-list-update/git"
 	"github.com/knqyf263/vuln-list-update/nvd"
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	target = flag.String("target", "", "update target (nvd, alpine, redhat, debian, ubuntu)")
+	target = flag.String("target", "", "update target (nvd, alpine, redhat, debian, ubuntu, archlinux)")
 	years  = flag.String("years", "", "update years (only redhat)")
 )
 
@@ -92,6 +92,11 @@ func run() error {
 			return xerrors.Errorf("error in Alpine update: %w", err)
 		}
 		commitMsg = "Alpine Issue Tracker"
+	case "archlinux":
+		if err := archlinux.Update(); err != nil {
+			return xerrors.Errorf("error in Archlinux update: %w", err)
+		}
+		commitMsg = "Archlinux Issue Tracker"
 	default:
 		return xerrors.New("unknown target")
 	}


### PR DESCRIPTION
Add archlinux support! 

JSON sample.
```
{
  "package": "openssh",
  "status": "Fixed",
  "affected": "7.3p1-2",
  "fixed": "7.4p1-1",
  "ticket": null,
  "name": "CVE-2016-10011",
  "groups": [
    "AVG-110"
  ],
  "type": "information disclosure",
  "severity": "Low",
  "vector": "Local",
  "description": "It was found that there is a theoretical leak of host private key material to privilege-separated child processes via realloc() when reading keys. No such leak was observed in practice for normal-sized keys, nor does a leak to the child processes directly expose key material to unprivileged users.",
  "advisories": [
    "ASA-201612-20"
  ],
  "references": [
    "https://www.openssh.com/txt/release-7.4",
    "http://seclists.org/oss-sec/2016/q4/705"
  ],
  "notes": null
}
```

Use these infomations.
https://security.archlinux.org/AVG-110.json
https://security.archlinux.org/CVE-2016-10011.json

