### PR TITLE
chore(amazon): fetch ALAS by cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ stages:
   - 'Debian Security Bug Tracker'
   - 'Debian OVAL'
   - 'Ubuntu CVE Tracker'
+  - 'Amazon Linux AMI Security Advisory'
   - 'Red Hat Security Data API 2019-2020'
   - 'Red Hat Security Data API 2018'
   - 'Red Hat Security Data API 2017'
@@ -54,6 +55,11 @@ jobs:
       if: type = cron
       script:
         - go run main.go -target ubuntu
+
+    - stage: 'Amazon Linux AMI Security Advisory'
+      if: type = cron
+      script:
+        - go run main.go -target amazon
     
     # split RedHat job due to timeout
     - stage: 'Red Hat Security Data API 1996-2002'


### PR DESCRIPTION
ALAS (Amazon Linux AMI Security Advisory) should be fetched daily on CronJob of Travis CI