### PR TITLE
Fix: Migrate Red Hat Security Data API to OVAL v2

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,8 @@
 name: Update vuln-list repo
 on:
   schedule:
-    - cron: "0 0,12 * * *"
-      
+  - cron: "0 0,12 * * *"
+
 jobs:
   update:
     name: Update repo vuln-list

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,8 @@
 name: Update vuln-list repo
 on:
   schedule:
-  - cron: "0 0,12 * * *"
-
+    - cron: "0 0,12 * * *"
+      
 jobs:
   update:
     name: Update repo vuln-list

--- a/oval/redhat/redhat.go
+++ b/oval/redhat/redhat.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -32,7 +31,6 @@ const (
 )
 
 var (
-	regexCVEFormat               = regexp.MustCompile(`CVE-\d{4,}-\d{4,}`)
 	releases                     = []string{"6"}
 	releasesIncludingUnpatchVuln = []string{"7", "8"}
 )
@@ -148,12 +146,6 @@ func (c Config) saveRHSAPerYear(dirName string, rhsaID string, data interface{})
 
 func (c Config) saveCVEPerYear(dirName string, cveID string, data interface{}) error {
 	// e.g. CVE-2013-7488
-	cveIDs := regexCVEFormat.FindStringSubmatch(cveID)
-	if len(cveIDs) < 1 {
-		log.Printf("invalid CVE-ID format: %s\n", cveID)
-		return ErrInvalidCVEFormat
-	}
-	cveID = cveIDs[0]
 	s := strings.Split(cveID, "-")
 	if len(s) != 3 {
 		log.Printf("invalid CVE-ID format: %s\n", cveID)

--- a/oval/redhat/redhat.go
+++ b/oval/redhat/redhat.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -21,46 +22,61 @@ import (
 const (
 	ovalDir   = "oval"
 	redhatDir = "redhat"
-	urlFormat = "https://www.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s.oval.xml.bz2"
-	retry     = 5
+
+	classVulnerability = "vulnerability"
+
+	urlFormat                   = "https://www.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s.oval.xml.bz2"
+	urlFormatIncludingUnpatched = "https://www.redhat.com/security/data/oval/v2/beta/RHEL%s/rhel-%s-including-unpatched.oval.xml.bz2"
+
+	retry = 5
 )
 
 var (
-	releases = []string{"6", "7", "8"}
+	regexCVEFormat               = regexp.MustCompile(`CVE-\d{4,}-\d{4,}`)
+	releases                     = []string{"6"}
+	releasesIncludingUnpatchVuln = []string{"7", "8"}
 )
 
 var (
 	ErrInvalidRHSAFormat = errors.New("invalid RHSA-ID format")
+	ErrInvalidCVEFormat  = errors.New("invalid CVE-ID format")
 )
 
 type Config struct {
-	VulnListDir string
-	URLFormat   string
-	AppFs       afero.Fs
-	Retry       int
+	VulnListDir                 string
+	URLFormat                   string
+	URLFormatIncludingUnpatched string
+	AppFs                       afero.Fs
+	Retry                       int
 }
 
 func NewConfig() Config {
 	return Config{
-		VulnListDir: utils.VulnListDir(),
-		URLFormat:   urlFormat,
-		AppFs:       afero.NewOsFs(),
-		Retry:       retry,
+		VulnListDir:                 utils.VulnListDir(),
+		URLFormat:                   urlFormat,
+		URLFormatIncludingUnpatched: urlFormatIncludingUnpatched,
+		AppFs:                       afero.NewOsFs(),
+		Retry:                       retry,
 	}
 }
 
 func (c Config) Update() error {
 	log.Println("Fetching Red Hat OVAL data...")
 	for _, release := range releases {
-		if err := c.update(release); err != nil {
+		if err := c.update(release, c.URLFormat); err != nil {
+			return err
+		}
+	}
+	for _, release := range releasesIncludingUnpatchVuln {
+		if err := c.update(release, c.URLFormatIncludingUnpatched); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c Config) update(release string) error {
-	url := fmt.Sprintf(c.URLFormat, release, release)
+func (c Config) update(release string, formattedURL string) error {
+	url := fmt.Sprintf(formattedURL, release, release)
 	res, err := utils.FetchURL(url, "", c.Retry)
 	if err != nil {
 		return xerrors.Errorf("failed to fetch Red Hat OVAL: %w", err)
@@ -77,6 +93,17 @@ func (c Config) update(release string) error {
 	dir := filepath.Join(ovalDir, redhatDir, release)
 	bar := pb.StartNew(len(ovalroot.Definitions.Definitions))
 	for _, def := range ovalroot.Definitions.Definitions {
+		if def.Class == classVulnerability {
+			if err = c.saveCVEPerYear(dir, def.References[0].RefID, def); err != nil {
+				switch err {
+				case ErrInvalidCVEFormat:
+					continue
+				default:
+					return xerrors.Errorf("unable to save CVE: %w", err)
+				}
+			}
+			continue
+		}
 		titles := strings.Fields(def.Title)
 		title := strings.Trim(titles[0], ":")
 		if err = c.saveRHSAPerYear(dir, title, def); err != nil {
@@ -112,6 +139,31 @@ func (c Config) saveRHSAPerYear(dirName string, rhsaID string, data interface{})
 	}
 
 	filePath := filepath.Join(yearDir, fmt.Sprintf("%s.json", rhsaID))
+	fs := utils.NewFs(c.AppFs)
+	if err := fs.WriteJSON(filePath, data); err != nil {
+		return xerrors.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+func (c Config) saveCVEPerYear(dirName string, cveID string, data interface{}) error {
+	// e.g. CVE-2013-7488
+	cveIDs := regexCVEFormat.FindStringSubmatch(cveID)
+	if len(cveIDs) < 1 {
+		log.Printf("invalid CVE-ID format: %s\n", cveID)
+		return ErrInvalidCVEFormat
+	}
+	cveID = cveIDs[0]
+	s := strings.Split(cveID, "-")
+	if len(s) != 3 {
+		log.Printf("invalid CVE-ID format: %s\n", cveID)
+		return ErrInvalidCVEFormat
+	}
+	yearDir := filepath.Join(c.VulnListDir, dirName, s[1])
+	if err := c.AppFs.MkdirAll(yearDir, os.ModePerm); err != nil {
+		return xerrors.Errorf("failed to create a year dir: %w", err)
+	}
+	filePath := filepath.Join(yearDir, fmt.Sprintf("%s.json", cveID))
 	fs := utils.NewFs(c.AppFs)
 	if err := fs.WriteJSON(filePath, data); err != nil {
 		return xerrors.Errorf("failed to write file: %w", err)

--- a/oval/redhat/redhat_test.go
+++ b/oval/redhat/redhat_test.go
@@ -100,10 +100,11 @@ func TestConfig_Update(t *testing.T) {
 			fmt.Println(u)
 			appFs := afero.NewMemMapFs()
 			c := Config{
-				VulnListDir: "/tmp",
-				URLFormat:   u,
-				AppFs:       appFs,
-				Retry:       0,
+				VulnListDir:                 "/tmp",
+				URLFormat:                   u,
+				URLFormatIncludingUnpatched: u,
+				AppFs:                       appFs,
+				Retry:                       0,
 			}
 			err := c.Update()
 			switch {

--- a/scripts/compare_redhat_cves.go
+++ b/scripts/compare_redhat_cves.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aquasecurity/vuln-list-update/oval/redhat"
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+func main() {
+	cve := make(map[string]bool)
+	ovalDir := utils.VulnListDir() + "/oval/redhat"
+	if errWalk := filepath.Walk(ovalDir, func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasPrefix(info.Name(), "CVE-") {
+			cveID := strings.Replace(info.Name(), ".json", "", 1)
+			cve[cveID] = true
+			return nil
+		}
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var rhsa redhat.Definition
+		err = json.Unmarshal(content, &rhsa)
+		if err != nil {
+			return err
+		}
+		for _, c := range rhsa.Advisory.Cves {
+			cve[c.CveID] = true
+		}
+		return nil
+	}); errWalk != nil {
+		log.Fatal(errWalk)
+	}
+
+	var missingCVEs []string
+	redHatDir := utils.VulnListDir() + "/redhat"
+	if errWalk := filepath.Walk(redHatDir, func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+		cveID := strings.Replace(info.Name(), ".json", "", 1)
+		yearStr := strings.Split(cveID, "-")[1]
+		year, _ := strconv.Atoi(yearStr)
+		if year < 2011 {
+			return nil
+		}
+		if _, ok := cve[cveID]; !ok {
+			missingCVEs = append(missingCVEs, cveID)
+		}
+		return nil
+	}); errWalk != nil {
+		log.Fatal(errWalk)
+	}
+	fmt.Println(strings.Join(missingCVEs, ", "))
+}


### PR DESCRIPTION
* Added compare script to print missing CVEs in RedHat and RedHat-oval
* Updated oval/Redhat to parse unpatched vulnerability