### PR TITLE
feat: utilise golangci-lint-action in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,13 +15,10 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
     
-    - name: Install GolangCI-Lint
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $version
-      env:
-        version: v1.31.0
-
     - name: Lint
-      run: ./bin/golangci-lint run
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.31
           
     - name: Test
       run: |


### PR DESCRIPTION
* utilised the [`golangci-lint-action`](https://github.com/golangci/golangci-lint-action) GitHub action in the workflow instead of manually installing `golangci` and running it
* closes #51 