### PR TITLE
deprecate set env in Github Actions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set Owner
-      run: echo ::set-env name=VULNLIST_REPOSITORY_OWNER::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $1}' | sed -e "s/:refs//")
+      run: echo $(echo "$GITHUB_REPOSITORY" | awk -F / '{print $1}' | sed -e "s/:refs//") >> $VULNLIST_REPOSITORY_OWNER
       shell: bash
 
     - name: Setup github user email and name


### PR DESCRIPTION
Closes #54

This MR removes the `set-env` command in Github Actions