### PR TITLE
fix(cvrf/suse): handle invalid UTF-8 characters

### DIFF
--- a/cvrf/suse/suse.go
+++ b/cvrf/suse/suse.go
@@ -86,8 +86,7 @@ func (c Config) update(os string, urls []string) error {
 
 		if !utf8.Valid(cvrfXml) {
 			log.Println("invalid UTF-8")
-			s := strings.ToValidUTF8(string(cvrfXml), "")
-			cvrfXml = []byte(s)
+			cvrfXml = []byte(strings.ToValidUTF8(string(cvrfXml), ""))
 		}
 
 		err = xml.Unmarshal(cvrfXml, &cv)

--- a/cvrf/suse/suse.go
+++ b/cvrf/suse/suse.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/aquasecurity/vuln-list-update/utils"
 	"github.com/cheggaaa/pb"
@@ -79,9 +80,16 @@ func (c Config) update(os string, urls []string) error {
 	for _, cvrfXml := range cvrfXmls {
 		var cv Cvrf
 		if len(cvrfXml) == 0 {
-			log.Printf("empty CVRF xml: %s", cv.Tracking.ID)
+			log.Println("empty CVRF xml")
 			continue
 		}
+
+		if !utf8.Valid(cvrfXml) {
+			log.Println("invalid UTF-8")
+			s := strings.ToValidUTF8(string(cvrfXml), "")
+			cvrfXml = []byte(s)
+		}
+
 		err = xml.Unmarshal(cvrfXml, &cv)
 		if err != nil {
 			return xerrors.Errorf("failed to decode SUSE XML: %w", err)

--- a/cvrf/suse/suse_test.go
+++ b/cvrf/suse/suse_test.go
@@ -40,6 +40,9 @@ func TestConfig_Update(t *testing.T) {
 				"/pub/projects/security/cvrf/cvrf-opensuse-su-2015-1289-1.xml": "testdata/cvrf-opensuse-su-2015-1289-1.xml",
 				"/pub/projects/security/cvrf/cvrf-opensuse-su-2016-3233-1.xml": "testdata/cvrf-opensuse-su-2016-3233-1.xml",
 				"/pub/projects/security/cvrf/cvrf-opensuse-su-2018-1633-1.xml": "testdata/cvrf-opensuse-su-2018-1633-1.xml",
+
+				// include invalid UTF-8 characters
+				"/pub/projects/security/cvrf/cvrf-opensuse-su-2016-0874-1.xml": "testdata/cvrf-opensuse-su-2016-0874-1.xml",
 			},
 			goldenFiles: map[string]string{
 				"/tmp/cvrf/suse/suse/2018/SUSE-SU-2018-1784-1.json":         "testdata/golden/SUSE-SU-2018-1784-1.json",
@@ -52,6 +55,7 @@ func TestConfig_Update(t *testing.T) {
 				"/tmp/cvrf/suse/opensuse/2015/openSUSE-SU-2015-1289-1.json": "testdata/golden/openSUSE-SU-2015-1289-1.json",
 				"/tmp/cvrf/suse/opensuse/2016/openSUSE-SU-2016-3233-1.json": "testdata/golden/openSUSE-SU-2016-3233-1.json",
 				"/tmp/cvrf/suse/opensuse/2018/openSUSE-SU-2018-1633-1.json": "testdata/golden/openSUSE-SU-2018-1633-1.json",
+				"/tmp/cvrf/suse/opensuse/2016/openSUSE-SU-2016-0874-1.json": "testdata/golden/openSUSE-SU-2016-0874-1.json",
 			},
 		},
 		{
@@ -137,7 +141,7 @@ func TestConfig_Update(t *testing.T) {
 				fileCount += 1
 
 				actual, err := afero.ReadFile(c.AppFs, path)
-				assert.NoError(t, err, tc.name)
+				require.NoError(t, err, tc.name)
 
 				goldenPath, ok := tc.goldenFiles[path]
 				assert.True(t, ok, tc.name)

--- a/cvrf/suse/testdata/cvrf-list.html
+++ b/cvrf/suse/testdata/cvrf-list.html
@@ -12,3 +12,4 @@
 <a href="cvrf-opensuse-su-2015-1289-1.xml">cvrf-opensuse-su-2015-1289-1.xml</a>                            11-Jan-2018 00:44    9820
 <a href="cvrf-opensuse-su-2016-3233-1.xml">cvrf-opensuse-su-2016-3233-1.xml</a>                            11-Jan-2018 00:44    9820
 <a href="cvrf-opensuse-su-2018-1633-1.xml">cvrf-opensuse-su-2018-1633-1.xml</a>                            11-Jan-2018 00:44    9820
+<a href="cvrf-opensuse-su-2016-0874-1.xml">cvrf-opensuse-su-2016-0874-1.xml</a>                            20-Feb-2016 12:34    9820

--- a/cvrf/suse/testdata/cvrf-opensuse-su-2016-0874-1.xml
+++ b/cvrf/suse/testdata/cvrf-opensuse-su-2016-0874-1.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1"
+><DocumentTitle xml:lang="en"
+>Security update for dropbear</DocumentTitle
+><DocumentType
+>SUSE Patch</DocumentType
+><DocumentPublisher Type="Vendor"
+><ContactDetails
+>security@suse.de</ContactDetails
+><IssuingAuthority
+>SUSE Security Team</IssuingAuthority
+></DocumentPublisher
+><DocumentTracking
+><Identification
+><ID
+>openSUSE-SU-2016:0874-1</ID
+></Identification
+><Status
+>Final</Status
+><Version
+>1</Version
+><RevisionHistory
+><Revision
+><Number
+>1</Number
+><Date
+>2016-03-24T10:25:34Z</Date
+><Description
+>current</Description
+></Revision
+></RevisionHistory
+><InitialReleaseDate
+>2016-03-24T10:25:34Z</InitialReleaseDate
+><CurrentReleaseDate
+>2016-03-24T10:25:34Z</CurrentReleaseDate
+><Generator
+><Engine
+>cve-database/bin/generate-cvrf.pl</Engine
+><Date
+>2017-02-24T01:00:00Z</Date
+></Generator
+></DocumentTracking
+><DocumentNotes
+><Note Title="Topic" Type="Summary" Ordinal="1" xml:lang="en"
+>Security update for dropbear</Note
+><Note Title="Details" Type="General" Ordinal="2" xml:lang="en"
+>
+This update for dropbear fixes the following issues:
+
+- dropbear was updated to upstream version 2016.72
+  * Validate X11 forwarding input. Could allow bypass of authorized_keys command= restrictions,
+    found by github.com/tintinweb. Thanks for Damien Miller for a patch.
+- used as bug fix release for boo#970633 - CVE-2016-3116
+
+- dropbear was updated to upstream version 2015.71
+  * Fix 'bad buf_incrpos' when data is transferred, broke in 2015.69
+  * Fix crash on exit when -p address:port is used, broke in 2015.68
+  * Fix building with only ENABLE_CLI_REMOTETCPFWD given, patch from Konstantin Tokarev
+  * Fix bad configure script test which didn't work with dash shell, patch from Juergen Daubert,
+    broke in 2015.70
+  * Fix server race condition that could cause sessions to hang on exit,
+    https://github.com/robotframework/SSHLibrary/issues/128
+
+- dropbear was updated to upstream version 2015.70
+  * Fix server password authentication on Linux, broke in 2015.69
+  * Fix crash when forwarded TCP connections fail to connect (bug introduced in 2015.68)
+  * Avoid hang on session close when multiple sessions are started, affects Qt Creator
+    Patch from Andrzej Szombierski
+  * Reduce per-channel memory consumption in common case, increase default
+    channel limit from 100 to 1000 which should improve SOCKS forwarding for modern
+    webpages
+  * Handle multiple command line arguments in a single flag, thanks to Guilhem Moulin
+  * Manpage improvements from Guilhem Moulin
+  * Build fixes for Android from Mike Frysinger
+  * Don't display the MOTD when an explicit command is run from Guilhem Moulin
+  * Check curve25519 shared secret isn't zero
+
+- dropbear was updated to upstream version 2015.68
+  * Reduce local data copying for improved efficiency. Measured 30%
+    increase in throughput for connections to localhost
+  * Forwarded TCP ports connect asynchronously and try all available addresses
+    (IPv4, IPv6, round robin DNS)
+  * Fix all compile warnings, many patches from Gaël Portay
+    Note that configure with -Werror may not be successful on some platforms (OS X)
+    and some configuration options may still result in unused variable
+    warnings.
+  * Use TCP Fast Open on Linux if available. Saves a round trip at connection
+    to hosts that have previously been connected.
+    Needs a recent Linux kernel and possibly 'sysctl -w net.ipv4.tcp_fastopen=3'
+    Client side is disabled by default pending further compatibility testing
+    with networks and systems.
+  * Increase maximum command length to 9000 bytes
+  * Free memory before exiting, patch from Thorsten Horstmann. Useful for
+    Dropbear ports to embedded systems and for checking memory leaks
+    with valgrind. Only partially implemented for dbclient.
+    This is disabled by default, enable with DROPBEAR_CLEANUP in sysoptions.h
+  * DROPBEAR_DEFAULT_CLI_AUTHKEY setting now always prepends home directory unless
+    there is a leading slash (~ isn't treated specially)
+  * Fix small ECC memory leaks
+  * Tighten validation of Diffie-Hellman parameters, from Florent Daigniere of
+    Matta Consulting. Odds of bad values are around 2**-512 -- improbable.
+  * Twofish-ctr cipher is supported though disabled by default
+  * Fix pre-authentication timeout when waiting for client SSH-2.0 banner, thanks
+    to CL Ouyang
+  * Fix null pointer crash with restrictions in authorized_keys without a command, patch from
+    Guilhem Moulin
+  * Ensure authentication timeout is handled while reading the initial banner,
+    thanks to CL Ouyang for finding it.
+  * Fix null pointer crash when handling bad ECC keys. Found by afl-fuzz
+
+- dropbear was updated to upstream version 2015.67
+  * Call fsync() after generating private keys to ensure they aren't lost if a
+    reboot occurs. Thanks to Peter Korsgaard
+  * Disable non-delayed zlib compression by default on the server. Can be
+    enabled if required for old clients with DROPBEAR_SERVER_DELAY_ZLIB
+  * Default client key path ~/.ssh/id_dropbear
+  * Prefer stronger algorithms by default, from Fedor Brunner. 
+    AES256 over 3DES
+    Diffie-hellman group14 over group1
+  * Add option to disable CBC ciphers.
+  * Disable twofish in default options.h
+  * Enable sha2 HMAC algorithms by default, the code was already required
+    for ECC key exchange. sha1 is the first preference still for performance. 
+  * Fix installing dropbear.8 in a separate build directory, from Like Ma
+  * Allow configure to succeed if libtomcrypt/libtommath are missing, from Elan Ruusamäe
+  * Don't crash if ssh-agent provides an unknown type of key. From Catalin Patulea
+  * Minor bug fixes, a few issues found by Coverity scan 
+
+- dropbear was updated to upstream version 2014.66
+  * Use the same keepalive handling behaviour as OpenSSH. This will work better
+    with some SSH implementations that have different behaviour with unknown
+    message types.
+  * Don't reply with SSH_MSG_UNIMPLEMENTED when we receive a reply to our own
+    keepalive message
+  * Set $SSH_CLIENT to keep bash happy, patch from Ryan Cleere
+  * Fix wtmp which broke since 2013.62, patch from Whoopie
+
+- dropbear was updated to upstream version 2014.65
+  * Fix 2014.64 regression, server session hang on exit with scp (and probably
+    others), thanks to NiLuJe for tracking it down
+  * Fix 2014.64 regression, clock_gettime() error handling which broke on older
+    Linux kernels, reported by NiLuJe
+  * Fix 2014.64 regression, writev() could occassionally fail with EAGAIN which
+    wasn't caught
+  * Avoid error message when trying to set QoS on proxycommand or multihop pipes
+  * Use /usr/bin/xauth, thanks to Mike Frysinger
+  * Don't exit the client if the local user entry can't be found, thanks to iquaba
+
+- added missing systemd entries for dropbear-keygen.service
+- dropbear was updated to upstream version 2014.64
+  * Fix compiling with ECDSA and DSS disabled
+  * Don't exit abruptly if too many outgoing packets are queued for writev(). Patch
+    thanks to Ronny Meeus
+  * The -K keepalive option now behaves more like OpenSSH's 'ServerAliveInterval'.
+    If no response is received after 3 keepalives then the session is terminated. This
+    will close connections faster than waiting for a TCP timeout.
+  * Rework TCP priority setting. New settings are
+    if (connecting || ptys || x11) tos = LOWDELAY
+    else if (tcp_forwards) tos = 0
+    else tos = BULK
+    Thanks to Catalin Patulea for the suggestion.
+  * Improve handling of many concurrent new TCP forwarded connections, should now
+    be able to handle as many as MAX_CHANNELS. Thanks to Eduardo Silva for reporting
+    and investigating it.
+  * Make sure that exit messages from the client are printed, regression in 2013.57
+  * Use monotonic clock where available, timeouts won't be affected by system time
+    changes
+  * Add -V for version
+
+- dropbear was updated regular init script to also create ECDSA keys
+
+- update to upstream version 2014.63
+  * Fix ~. to terminate a client interactive session after waking a laptop
+  from sleep.
+  * Changed port separator syntax again, now using host^port. This is because
+  IPv6 link-local addresses use %. Reported by Gui Iribarren
+  * Avoid constantly relinking dropbearmulti target, fix 'make install'
+  for multi target, thanks to Mike Frysinger
+  * Avoid getting stuck in a loop writing huge key files, reported by Bruno
+  Thomsen
+  * Don't link dropbearkey or dropbearconvert to libz or libutil,
+  thanks to Nicolas Boos
+  * Fix linking -lcrypt on systems without /usr/lib, thanks to Nicolas Boos
+  * Avoid crash on exit due to cleaned up keys before last packets are sent,
+  debugged by Ronald Wahl
+  * Fix a race condition in rekeying where Dropbear would exit if it received a
+  still-in-flight packet after initiating rekeying. Reported by Oliver Metz.
+  This is a longstanding bug but is triggered more easily since 2013.57
+  * [...]
+- dropbear was updated service files and activated building of ecdsa keys
+- only package the old init service in distributions without systemd
+
+- imported upstream version 2013.62
+  * Disable 'interactive' QoS connection options when a connection doesn't
+    have a PTY (eg scp, rsync). Thanks to Catalin Patulea for the patch.
+  * Log when a hostkey is generated with -R, fix some bugs in handling server
+    hostkey commandline options
+  * Fix crash in Dropbearconvert and 521 bit key, reported by NiLuJe
+  * Update config.guess and config.sub again
+  * ECC (elliptic curve) support. Supports ECDSA hostkeys (requires new keys to
+    be generated) and ECDH for setting up encryption keys (no intervention
+    required). This is significantly faster.
+  * curve25519-sha256@libssh.org support for setting up encryption keys. This is
+    another elliptic curve mode with less potential of NSA interference in
+    algorithm parameters. curve25519-donna code thanks to Adam Langley
+  * -R option to automatically generate hostkeys. This is recommended for
+    embedded platforms since it allows the system random number device
+    /dev/urandom a longer startup time to generate a secure seed before the
+    hostkey is required.
+  * Compile fixes for old vendor compilers like Tru64 from Daniel Richard G.
+  * Make authorized_keys handling more robust, don't exit encountering
+    malformed lines. Thanks to Lorin Hochstein and Mark Stillwell
+</Note
+><Note Title="Terms of Use" Type="Legal Disclaimer" Ordinal="3" xml:lang="en"
+>The CVRF data is provided by SUSE under the Creative Commons License 4.0 with Attribution for Non-Commercial usage (CC-BY-NC-4.0).</Note
+></DocumentNotes
+><DocumentDistribution xml:lang="en"
+>Copyright SUSE LLC under the Creative Commons License 4.0 with Attribution for Non-Commercial usage (CC-BY-NC-4.0)</DocumentDistribution
+><DocumentReferences
+><Reference Type="Self"
+><URL
+>http://lists.opensuse.org/opensuse-updates/2016-03/msg00105.html</URL
+><Description
+>E-Mail link for openSUSE-SU-2016:0874-1</Description
+></Reference
+><Reference Type="Self"
+><URL
+>https://www.suse.com/support/security/rating/</URL
+><Description
+>SUSE Security Ratings</Description
+></Reference
+></DocumentReferences
+><ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1"
+><Branch Type="Product Version" Name="dropbear-2016.72-2.7.1"
+><FullProductName ProductID="dropbear-2016.72-2.7.1"
+>dropbear-2016.72-2.7.1</FullProductName
+></Branch
+></ProductTree
+><Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1"
+><Notes
+><Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en"
+>CRLF injection vulnerability in Dropbear SSH before 2016.72 allows remote authenticated users to bypass intended shell-command restrictions via crafted X11 forwarding data.</Note
+></Notes
+><CVE
+>CVE-2016-3116</CVE
+><ProductStatuses
+><Status Type="Fixed"
+></Status
+></ProductStatuses
+><Threats
+><Threat Type="Impact"
+><Description
+>moderate</Description
+></Threat
+></Threats
+><Remediations
+><Remediation Type="Vendor Fix"
+><Description xml:lang="en"
+>Please Install the update.</Description
+><URL
+>http://lists.opensuse.org/opensuse-updates/2016-03/msg00105.html</URL
+></Remediation
+></Remediations
+><References
+><Reference
+><URL
+>https://www.suse.com/security/cve/CVE-2016-3116.html</URL
+><Description
+>CVE-2016-3116</Description
+></Reference
+><Reference
+><URL
+>https://bugzilla.suse.com/970633</URL
+><Description
+>SUSE Bug 970633</Description
+></Reference
+></References
+></Vulnerability
+></cvrfdoc
+>

--- a/cvrf/suse/testdata/golden/openSUSE-SU-2016-0874-1.json
+++ b/cvrf/suse/testdata/golden/openSUSE-SU-2016-0874-1.json
@@ -1,0 +1,76 @@
+{
+  "Title": "Security update for dropbear",
+  "Tracking": {
+    "ID": "openSUSE-SU-2016:0874-1",
+    "Status": "Final",
+    "Version": "1",
+    "InitialReleaseDate": "2016-03-24T10:25:34Z",
+    "CurrentReleaseDate": "2016-03-24T10:25:34Z",
+    "RevisionHistory": [
+      {
+        "Number": "1",
+        "Date": "2016-03-24T10:25:34Z",
+        "Description": "current"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "Security update for dropbear",
+      "Title": "Topic",
+      "Type": "Summary"
+    },
+    {
+      "Text": "\nThis update for dropbear fixes the following issues:\n\n- dropbear was updated to upstream version 2016.72\n  * Validate X11 forwarding input. Could allow bypass of authorized_keys command= restrictions,\n    found by github.com/tintinweb. Thanks for Damien Miller for a patch.\n- used as bug fix release for boo#970633 - CVE-2016-3116\n\n- dropbear was updated to upstream version 2015.71\n  * Fix 'bad buf_incrpos' when data is transferred, broke in 2015.69\n  * Fix crash on exit when -p address:port is used, broke in 2015.68\n  * Fix building with only ENABLE_CLI_REMOTETCPFWD given, patch from Konstantin Tokarev\n  * Fix bad configure script test which didn't work with dash shell, patch from Juergen Daubert,\n    broke in 2015.70\n  * Fix server race condition that could cause sessions to hang on exit,\n    https://github.com/robotframework/SSHLibrary/issues/128\n\n- dropbear was updated to upstream version 2015.70\n  * Fix server password authentication on Linux, broke in 2015.69\n  * Fix crash when forwarded TCP connections fail to connect (bug introduced in 2015.68)\n  * Avoid hang on session close when multiple sessions are started, affects Qt Creator\n    Patch from Andrzej Szombierski\n  * Reduce per-channel memory consumption in common case, increase default\n    channel limit from 100 to 1000 which should improve SOCKS forwarding for modern\n    webpages\n  * Handle multiple command line arguments in a single flag, thanks to Guilhem Moulin\n  * Manpage improvements from Guilhem Moulin\n  * Build fixes for Android from Mike Frysinger\n  * Don't display the MOTD when an explicit command is run from Guilhem Moulin\n  * Check curve25519 shared secret isn't zero\n\n- dropbear was updated to upstream version 2015.68\n  * Reduce local data copying for improved efficiency. Measured 30%\n    increase in throughput for connections to localhost\n  * Forwarded TCP ports connect asynchronously and try all available addresses\n    (IPv4, IPv6, round robin DNS)\n  * Fix all compile warnings, many patches from Gal Portay\n    Note that configure with -Werror may not be successful on some platforms (OS X)\n    and some configuration options may still result in unused variable\n    warnings.\n  * Use TCP Fast Open on Linux if available. Saves a round trip at connection\n    to hosts that have previously been connected.\n    Needs a recent Linux kernel and possibly 'sysctl -w net.ipv4.tcp_fastopen=3'\n    Client side is disabled by default pending further compatibility testing\n    with networks and systems.\n  * Increase maximum command length to 9000 bytes\n  * Free memory before exiting, patch from Thorsten Horstmann. Useful for\n    Dropbear ports to embedded systems and for checking memory leaks\n    with valgrind. Only partially implemented for dbclient.\n    This is disabled by default, enable with DROPBEAR_CLEANUP in sysoptions.h\n  * DROPBEAR_DEFAULT_CLI_AUTHKEY setting now always prepends home directory unless\n    there is a leading slash (~ isn't treated specially)\n  * Fix small ECC memory leaks\n  * Tighten validation of Diffie-Hellman parameters, from Florent Daigniere of\n    Matta Consulting. Odds of bad values are around 2**-512 -- improbable.\n  * Twofish-ctr cipher is supported though disabled by default\n  * Fix pre-authentication timeout when waiting for client SSH-2.0 banner, thanks\n    to CL Ouyang\n  * Fix null pointer crash with restrictions in authorized_keys without a command, patch from\n    Guilhem Moulin\n  * Ensure authentication timeout is handled while reading the initial banner,\n    thanks to CL Ouyang for finding it.\n  * Fix null pointer crash when handling bad ECC keys. Found by afl-fuzz\n\n- dropbear was updated to upstream version 2015.67\n  * Call fsync() after generating private keys to ensure they aren't lost if a\n    reboot occurs. Thanks to Peter Korsgaard\n  * Disable non-delayed zlib compression by default on the server. Can be\n    enabled if required for old clients with DROPBEAR_SERVER_DELAY_ZLIB\n  * Default client key path ~/.ssh/id_dropbear\n  * Prefer stronger algorithms by default, from Fedor Brunner. \n    AES256 over 3DES\n    Diffie-hellman group14 over group1\n  * Add option to disable CBC ciphers.\n  * Disable twofish in default options.h\n  * Enable sha2 HMAC algorithms by default, the code was already required\n    for ECC key exchange. sha1 is the first preference still for performance. \n  * Fix installing dropbear.8 in a separate build directory, from Like Ma\n  * Allow configure to succeed if libtomcrypt/libtommath are missing, from Elan Ruusame\n  * Don't crash if ssh-agent provides an unknown type of key. From Catalin Patulea\n  * Minor bug fixes, a few issues found by Coverity scan \n\n- dropbear was updated to upstream version 2014.66\n  * Use the same keepalive handling behaviour as OpenSSH. This will work better\n    with some SSH implementations that have different behaviour with unknown\n    message types.\n  * Don't reply with SSH_MSG_UNIMPLEMENTED when we receive a reply to our own\n    keepalive message\n  * Set $SSH_CLIENT to keep bash happy, patch from Ryan Cleere\n  * Fix wtmp which broke since 2013.62, patch from Whoopie\n\n- dropbear was updated to upstream version 2014.65\n  * Fix 2014.64 regression, server session hang on exit with scp (and probably\n    others), thanks to NiLuJe for tracking it down\n  * Fix 2014.64 regression, clock_gettime() error handling which broke on older\n    Linux kernels, reported by NiLuJe\n  * Fix 2014.64 regression, writev() could occassionally fail with EAGAIN which\n    wasn't caught\n  * Avoid error message when trying to set QoS on proxycommand or multihop pipes\n  * Use /usr/bin/xauth, thanks to Mike Frysinger\n  * Don't exit the client if the local user entry can't be found, thanks to iquaba\n\n- added missing systemd entries for dropbear-keygen.service\n- dropbear was updated to upstream version 2014.64\n  * Fix compiling with ECDSA and DSS disabled\n  * Don't exit abruptly if too many outgoing packets are queued for writev(). Patch\n    thanks to Ronny Meeus\n  * The -K keepalive option now behaves more like OpenSSH's 'ServerAliveInterval'.\n    If no response is received after 3 keepalives then the session is terminated. This\n    will close connections faster than waiting for a TCP timeout.\n  * Rework TCP priority setting. New settings are\n    if (connecting || ptys || x11) tos = LOWDELAY\n    else if (tcp_forwards) tos = 0\n    else tos = BULK\n    Thanks to Catalin Patulea for the suggestion.\n  * Improve handling of many concurrent new TCP forwarded connections, should now\n    be able to handle as many as MAX_CHANNELS. Thanks to Eduardo Silva for reporting\n    and investigating it.\n  * Make sure that exit messages from the client are printed, regression in 2013.57\n  * Use monotonic clock where available, timeouts won't be affected by system time\n    changes\n  * Add -V for version\n\n- dropbear was updated regular init script to also create ECDSA keys\n\n- update to upstream version 2014.63\n  * Fix ~. to terminate a client interactive session after waking a laptop\n  from sleep.\n  * Changed port separator syntax again, now using host^port. This is because\n  IPv6 link-local addresses use %. Reported by Gui Iribarren\n  * Avoid constantly relinking dropbearmulti target, fix 'make install'\n  for multi target, thanks to Mike Frysinger\n  * Avoid getting stuck in a loop writing huge key files, reported by Bruno\n  Thomsen\n  * Don't link dropbearkey or dropbearconvert to libz or libutil,\n  thanks to Nicolas Boos\n  * Fix linking -lcrypt on systems without /usr/lib, thanks to Nicolas Boos\n  * Avoid crash on exit due to cleaned up keys before last packets are sent,\n  debugged by Ronald Wahl\n  * Fix a race condition in rekeying where Dropbear would exit if it received a\n  still-in-flight packet after initiating rekeying. Reported by Oliver Metz.\n  This is a longstanding bug but is triggered more easily since 2013.57\n  * [...]\n- dropbear was updated service files and activated building of ecdsa keys\n- only package the old init service in distributions without systemd\n\n- imported upstream version 2013.62\n  * Disable 'interactive' QoS connection options when a connection doesn't\n    have a PTY (eg scp, rsync). Thanks to Catalin Patulea for the patch.\n  * Log when a hostkey is generated with -R, fix some bugs in handling server\n    hostkey commandline options\n  * Fix crash in Dropbearconvert and 521 bit key, reported by NiLuJe\n  * Update config.guess and config.sub again\n  * ECC (elliptic curve) support. Supports ECDSA hostkeys (requires new keys to\n    be generated) and ECDH for setting up encryption keys (no intervention\n    required). This is significantly faster.\n  * curve25519-sha256@libssh.org support for setting up encryption keys. This is\n    another elliptic curve mode with less potential of NSA interference in\n    algorithm parameters. curve25519-donna code thanks to Adam Langley\n  * -R option to automatically generate hostkeys. This is recommended for\n    embedded platforms since it allows the system random number device\n    /dev/urandom a longer startup time to generate a secure seed before the\n    hostkey is required.\n  * Compile fixes for old vendor compilers like Tru64 from Daniel Richard G.\n  * Make authorized_keys handling more robust, don't exit encountering\n    malformed lines. Thanks to Lorin Hochstein and Mark Stillwell\n",
+      "Title": "Details",
+      "Type": "General"
+    },
+    {
+      "Text": "The CVRF data is provided by SUSE under the Creative Commons License 4.0 with Attribution for Non-Commercial usage (CC-BY-NC-4.0).",
+      "Title": "Terms of Use",
+      "Type": "Legal Disclaimer"
+    }
+  ],
+  "ProductTree": {
+    "Relationships": null
+  },
+  "References": [
+    {
+      "URL": "http://lists.opensuse.org/opensuse-updates/2016-03/msg00105.html",
+      "Description": "E-Mail link for openSUSE-SU-2016:0874-1"
+    },
+    {
+      "URL": "https://www.suse.com/support/security/rating/",
+      "Description": "SUSE Security Ratings"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2016-3116",
+      "Description": "CRLF injection vulnerability in Dropbear SSH before 2016.72 allows remote authenticated users to bypass intended shell-command restrictions via crafted X11 forwarding data.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2016-3116.html",
+          "Description": "CVE-2016-3116"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/970633",
+          "Description": "SUSE Bug 970633"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": null
+        }
+      ],
+      "CVSSScoreSets": {}
+    }
+  ]
+}


### PR DESCRIPTION
Fix the following issue
https://github.com/aquasecurity/vuln-list-update/runs/1337105587?check_suite_focus=true

SUSE recently added invalid UTF-8 characters to their CVRF. I'm sure it is a bug, but `vuln-list-update` should be able to handle it. This PR removes all invalid characters with `strings.ToValidUTF8`.