### PR TITLE
chore(actions): deprecate set-env

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set Owner
-      run: echo ::set-env name=VULNLIST_REPOSITORY_OWNER::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $1}' | sed -e "s/:refs//")
+      run: echo "VULNLIST_REPOSITORY_OWNER=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $1}' | sed -e 's/:refs//')" >> $GITHUB_ENV
       shell: bash
 
     - name: Setup github user email and name


### PR DESCRIPTION
Ref https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/