### PR TITLE
fix(photon): migrate the repository

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -54,8 +54,8 @@ jobs:
     - name: Red Hat OVA
       run: ./vuln-list-update -target redhat-oval
 
-    - name: Photon CVE Advisory
-      run: ./vuln-list-update -target photon
+#    - name: Photon CVE Advisory
+#      run: ./vuln-list-update -target photon
 
     - name: GitHub Security Advisory
       run: ./vuln-list-update -target ghsa

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -54,8 +54,8 @@ jobs:
     - name: Red Hat OVA
       run: ./vuln-list-update -target redhat-oval
 
-#    - name: Photon CVE Advisory
-#      run: ./vuln-list-update -target photon
+    - name: Photon CVE Advisory
+      run: ./vuln-list-update -target photon
 
     - name: GitHub Security Advisory
       run: ./vuln-list-update -target ghsa

--- a/photon/photon.go
+++ b/photon/photon.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	advisoryURL    = "https://vmware.bintray.com/photon_cve_metadata/"
+	advisoryURL    = "https://packages.vmware.com/photon/photon_cve_metadata/"
 	versionsFile   = "photon_versions.json"
 	advisoryFormat = "cve_data_photon%s.json"
 


### PR DESCRIPTION
Photon has migrated all of the repositories from Bintray to Packages.vmware.com.

This specific repository can be accessed from https://packages.vmware.com/photon/photon_cve_metadata/photon_versions.json