### PR TITLE
feat(redhat): add all OVAL files

### DIFF
--- a/oval/redhat/redhat.go
+++ b/oval/redhat/redhat.go
@@ -158,9 +158,6 @@ func (c Config) fetchOvalFilePaths() ([]string, error) {
 		if len(ss) < 3 {
 			return nil, xerrors.Errorf("failed to parse PULP_MANIFEST: %w", err)
 		}
-		if !strings.Contains(ss[0], "including-unpatched") {
-			continue
-		}
 
 		ovalFilePaths = append(ovalFilePaths, ss[0])
 	}


### PR DESCRIPTION
Some platforms such as EUS don't provide `-including-unpatched` files. They should also be included in vuln-list.