### PR TITLE
chore(ci): update advisories every 6 hours

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Update vuln-list repo
 on:
   schedule:
-  - cron: "0 0,12 * * *"
+  - cron: "0 */6 * * *"
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Report Card][report-card-img]][report-card]
 [![License][license-img]][license]
+[![Update vuln-list repo](https://github.com/aquasecurity/vuln-list-update/actions/workflows/update.yml/badge.svg)](https://github.com/aquasecurity/vuln-list-update/actions/workflows/update.yml)
 
 [report-card-img]: https://goreportcard.com/badge/github.com/aquasecurity/vuln-list-update
 [report-card]: https://goreportcard.com/report/github.com/aquasecurity/vuln-list-update
@@ -23,9 +24,6 @@ Usage of vuln-list-update:
   -years string
         update years (only redhat)
 ```
-
-## Cron status
-https://travis-ci.org/aquasecurity/vuln-list-update
 
 ## Author
 Teppei Fukuda (knqyf263)


### PR DESCRIPTION
Ubuntu is unstable recently. We should try again in a few hours, as I suppose that retries will further increase the load on the server and the server will return 503 again.

This PR will increase the frequency of advisory updates. It used to be every 12 hours and it is every 6 hours now.