### PR TITLE
ubuntu: remove vuln-dir before update

### DIFF
--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -24,6 +24,11 @@ const (
 )
 
 var (
+	targets = []string{
+		"active",
+		"ignored",
+		"retired",
+	}
 	statuses = []string{
 		"released",
 		"needed",
@@ -72,7 +77,7 @@ func Update() error {
 	}
 
 	log.Println("Walking Ubuntu...")
-	for _, target := range []string{"active", "retired"} {
+	for _, target := range targets {
 		if err := walkDir(filepath.Join(dir, target)); err != nil {
 			return err
 		}

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -96,8 +96,7 @@ func Update() error {
 
 	log.Println("walking ubuntu-cve-tracker ...")
 	for _, target := range targets {
-		err = walkDir(filepath.Join(dir, target))
-		if err != nil {
+		if err := walkDir(filepath.Join(dir, target)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
resolves #76 and #77

- also `git://git.launchpad.net/ubuntu-cve-tracker` to Ubuntu CVE tracker repo URL
- remove `vuln-list/ubuntu` before updating

~tested with workflow [here](https://github.com/ronaudinho/vuln-list-update/runs/2083195047?check_suite_focus=true), some results:~
- ~[CVE-2019-12378](https://github.com/ronaudinho/vuln-list/blob/dba362842c7eac3a0c54826b192e11130aa62a75/ubuntu/2019/CVE-2019-12378.json#L206)~
- ~[CVE-2019-12379](https://github.com/ronaudinho/vuln-list/blob/dba362842c7eac3a0c54826b192e11130aa62a75/ubuntu/2019/CVE-2019-12379.json#L206)~

tested with workflow [here](https://github.com/ronaudinho/vuln-list-update/runs/2083878438?check_suite_focus=true), both are [gone in latest vuln-list](https://github.com/ronaudinho/vuln-list/commit/2d0860d6b76d76a9f2ea24c35fdc40a72eb886f0), since [12378](https://git.launchpad.net/ubuntu-cve-tracker/tree/ignored/CVE-2019-12378) and [12379](https://git.launchpad.net/ubuntu-cve-tracker/tree/ignored/CVE-2019-12379) are ignored under current ubuntu-cve-tracker

### note
- skipping fetch seems to [cut jobs time by a lot](https://github.com/ronaudinho/vuln-list-update/runs/2082954737?check_suite_focus=true) - about 5 mins difference (ignore the failed push, I set env secret wrongly :facepalm:)
