### PR TITLE
ubuntu: remove dir if clone/pull fails halfway

### DIFF
--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -78,15 +78,14 @@ func Update() error {
 	dir := filepath.Join(utils.CacheDir(), cveTrackerDir)
 	for _, url := range repoURLs {
 		_, err = gc.CloneOrPull(url, dir, "master", false)
-		if err != nil {
-			log.Printf("failed to clone or pull: %s: %v", url, err)
-			log.Printf("removing %s directory", cveTrackerDir)
-			if err := os.RemoveAll(dir); err != nil {
-				return xerrors.Errorf("failed to remove %s directory: %w", cveTrackerDir, err)
-			}
-			continue
+		if err == nil {
+			break
 		}
-		break
+		log.Printf("failed to clone or pull: %s: %v", url, err)
+		log.Printf("removing %s directory", cveTrackerDir)
+		if err := os.RemoveAll(dir); err != nil {
+			return xerrors.Errorf("failed to remove %s directory: %w", cveTrackerDir, err)
+		}
 	}
 	if err != nil {
 		return xerrors.Errorf("failed to clone or pull: %w", err)

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -80,6 +80,10 @@ func Update() error {
 		_, err = gc.CloneOrPull(url, dir, "master", false)
 		if err != nil {
 			log.Printf("failed to clone or pull: %s: %v", url, err)
+			log.Printf("removing %s directory", cveTrackerDir)
+			if err := os.RemoveAll(dir); err != nil {
+				return xerrors.Errorf("failed to remove %s directory: %w", cveTrackerDir, err)
+			}
 			continue
 		}
 		break


### PR DESCRIPTION
resolves #76 and #77. failing fetch into existing git dir causes the next clone/pull attempt to fail, this adds removing said dir before retrying clone/pull.