### PR TITLE
Added Debian salsa also into Tracker

### DIFF
--- a/debian/salsa/debian.go
+++ b/debian/salsa/debian.go
@@ -1,0 +1,528 @@
+package salsa
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"golang.org/x/xerrors"
+
+	"github.com/cheggaaa/pb"
+	"github.com/pkg/errors"
+
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+const (
+	cloneCmd           = "clone --depth 1 https://salsa.debian.org/security-tracker-team/security-tracker.git"
+	debianDir          = "debian-salsa"
+	coveredReleasesURL = "http://security-tracker.debian.org/tracker/data/releases"
+	releasesURL        = "http://www.debian.org/releases/"
+)
+
+var releaseRegexp = regexp.MustCompile(`Debian (?:GNU/Linux )?(\d+)`)
+
+type dsa struct {
+	name        string
+	date        time.Time
+	description string
+	cves        []string
+	packages    []pkg
+}
+
+type pkg struct {
+	release, name, version, severity, statement string
+	willNotFix                                  bool
+	classification                              int64
+	severityClassification                      string
+}
+
+type cve struct {
+	name     string
+	reserved bool
+	notForUs bool
+	packages []pkg
+	notes    []string
+}
+
+var (
+	dsaLine     = regexp.MustCompile(`^\[(\d\d \w{3} \d{4})\] (D(?:S|L)A-\d+(?:-\d+)?)\s*(.*)`)
+	dsaCVEsLine = regexp.MustCompile(`(CVE-\d+-\d+)`)
+	dsaPkgLine  = regexp.MustCompile(`^\s*(?:\[(\w+)\]\s*)?- ([^\s]+) ([^\s]+)$`)
+)
+
+var (
+	cveLine      = regexp.MustCompile(`^(CVE-\d+-[0-9X]+)`)
+	notForUsLine = regexp.MustCompile(`^\s*NOT-FOR-US`)
+	noteLine     = regexp.MustCompile(`^\s*NOTE:\s*(.+)$`)
+	reservedLine = regexp.MustCompile(`^\s*RESERVED`)
+	packageLine  = regexp.MustCompile(`^\s*(?:\[(\w+)\]\s*)?- ([^\s]+) ([^\s]+)(?: \(([^\)]+)\))?`)
+	bugNumber    = regexp.MustCompile(`\s*;?\s*bug\s*#\d+\s*;?\s*`)
+)
+
+type DebianSalsa struct {
+	cloneCommand string
+	VulnListDir  string
+	oss          map[string]string
+	cveToDSA     map[string][]dsa
+	PackageData  map[string]map[string]CVERelease
+}
+
+type CVERelease struct {
+	Description string                    `json:"description"`
+	Releases    map[string]ReleaseDetails `json:"releases"`
+}
+type ReleaseDetails struct {
+	FixVersion             string                      `json:"fix_version,omitempty"`
+	WillNotFix             bool                        `json:"will_not_fix,omitempty"`
+	Severity               string                      `json:"severity,omitempty"`
+	Statement              string                      `json:"statement,omitempty"`
+	SecurityAdvisory       map[string]SecurityAdvisory `json:"security_advisory,omitempty"`
+	ClassificationID       int64                       `json:"classification_id,omitempty"`
+	SeverityClassification string                      `json:"severity_classification,omitempty"`
+}
+
+type VulnerabilityDetail struct {
+	Name                   string             `json:"name,omitempty"`
+	FixVersion             string             `json:"fix_version,omitempty"`
+	CVE                    string             `json:"cve,omitempty"`
+	WillNotFix             bool               `json:"will_not_fix,omitempty"`
+	Severity               string             `json:"severity,omitempty"`
+	Statement              string             `json:"statement,omitempty"`
+	SecurityAdvisory       []SecurityAdvisory `json:"security_advisory,omitempty"`
+	ClassificationID       int64              `json:"classification_id,omitempty"`
+	SeverityClassification string             `json:"severity_classification,omitempty"`
+}
+
+type debianStage struct {
+	fn   func() error
+	name string
+}
+
+var SeverityClassification = map[string]string{
+	"<no-dsa>":       "Fix Version: No DSA",
+	"<ignored>":      "Fix Version: Ignored",
+	"<postponed>":    "Fix Version: Postponed",
+	"<undetermined>": "Fix Version: Undetermined",
+}
+
+type SecurityAdvisory struct {
+	ID          string `json:"id,omitempty"`
+	Severity    string `json:"severity,omitempty"`
+	Description string `json:"description,omitempty"`
+	PublishDate string `json:"publish_date,omitempty"`
+}
+
+func NewClient() *DebianSalsa {
+	return &DebianSalsa{
+		cloneCommand: cloneCmd,
+		VulnListDir:  utils.VulnListDir(),
+		cveToDSA:     make(map[string][]dsa),
+		PackageData:  make(map[string]map[string]CVERelease),
+	}
+}
+
+func (ctx DebianSalsa) Update() error {
+	log.Println("Fetching Debian Salsa data...")
+	log.Println("Cloning repository", "git "+cloneCmd)
+	args := strings.Split(cloneCmd, " ")
+	_, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return errors.Wrap(err, "failed cloning repository")
+	}
+	defer os.RemoveAll("security-tracker") // nolint: errcheck
+	for _, stage := range []debianStage{
+		{ctx.getReleases, "getting releases"},
+		{ctx.parseDSAs, "parsing DSAs"},
+		{ctx.parseCVEs, "parsing CVEs"},
+	} {
+		err := stage.fn()
+		if err != nil {
+			return errors.Wrapf(err, "failed %s", stage.name)
+		}
+	}
+	/*go over all other releases, and if we haven't seen them, add them the same information from sid,
+	because it's true for them as well*/
+	for _, cveRelMap := range ctx.PackageData {
+		for _, relData := range cveRelMap {
+			if sidData, isSid := relData.Releases["unstable"]; isSid {
+				for relName, _ := range ctx.oss {
+					if _, seen := relData.Releases[relName]; !seen {
+						relData.Releases[relName] = sidData
+					}
+				}
+			}
+		}
+	}
+
+	log.Println("Saving new data")
+	bar := pb.StartNew(len(ctx.PackageData))
+	for pkgName, cveRelease := range ctx.PackageData {
+		pkgDir := filepath.Join(ctx.VulnListDir, debianDir, pkgName)
+		if err := os.MkdirAll(pkgDir, os.ModePerm); err != nil {
+			return xerrors.Errorf("failed to create the directory: %w", err)
+		}
+		for cveID, releases := range cveRelease {
+			filePath := filepath.Join(pkgDir, fmt.Sprintf("%s.json", cveID))
+			if err := utils.Write(filePath, releases); err != nil {
+				return xerrors.Errorf("failed to write Debian CVE details: %w", err)
+			}
+		}
+		bar.Increment()
+	}
+	bar.Finish()
+	return nil
+}
+func (ctx *DebianSalsa) getReleases() (err error) {
+	log.Println("Getting releases")
+	// start by getting Debian releases covered by the security tracker
+	// these are listed by codenames, so we will collect code names now, and later
+	// on get the actual version numbers
+	codeToVer := make(map[string]string)
+	//oss := make(map[string]int64)
+	log.Println("Fetching covered releases page", coveredReleasesURL)
+	doc, err := goquery.NewDocument(coveredReleasesURL)
+	if err != nil {
+		return err
+	}
+	rows := doc.Find("table tbody tr")
+	for i := range rows.Nodes {
+		row := rows.Eq(i)
+		td := row.Find("td")
+		// the first line is the header line and has <th> elements rather than <td> elements
+		if len(td.Nodes) == 0 {
+			continue
+		}
+		rel := td.Eq(0).Text()
+		// ignore backport releases
+		if strings.HasSuffix(rel, "-backports") {
+			continue
+		}
+		codeToVer[rel] = ""
+	}
+	// okay, let's get the version numbers for every release
+	codeToVer["unstable"] = "unstable" // this is always true
+	log.Println("Fetching releases page", releasesURL)
+	doc, err = goquery.NewDocument(releasesURL)
+	if err != nil {
+		return err
+	}
+	rows = doc.Find("#content ul li")
+	for i := range rows.Nodes {
+		a := rows.Eq(i).Find("a")
+		codeName := a.Find("q").Text()
+		if i == 0 {
+			codeToVer[codeName] = "testing"
+		} else {
+			// ignore codenames we don't know (because the security tracker
+			// doesn't support them)
+			if _, ok := codeToVer[codeName]; !ok {
+				continue
+			}
+			matches := releaseRegexp.FindStringSubmatch(a.Text())
+			if len(matches) < 2 {
+				return errors.Errorf("failed parsing release %s", codeName)
+			}
+			codeToVer[codeName] = matches[1]
+		}
+	}
+
+	// force Debian 7 (wheezy) to be in the releases we're covering. The Debian
+	// security tracker is not covering it anymore, but we will continue covering
+	// it (albeit incompletely, as new vulnerabilities will not be marked as
+	// affected for wheezy, although they should) until we inform customers that
+	// it has reached end of life (TODO: implement a formal EOL process)
+	codeToVer["wheezy"] = "7"
+	codeToVer["jessie"] = "8"
+	ctx.oss = codeToVer
+	return nil
+}
+func (ctx *DebianSalsa) parseDSAs() error {
+	log.Println("Getting advisories")
+	for _, tp := range []string{"DSA", "DLA"} {
+		dsaFile, err := os.Open("security-tracker/data/" + tp + "/list")
+		if err != nil {
+			return errors.Wrapf(err, "failed opening %s list", tp)
+		}
+		var currentDSA dsa
+		scanner := bufio.NewScanner(dsaFile)
+		for scanner.Scan() {
+			line := scanner.Text()
+			matches := dsaLine.FindStringSubmatch(line)
+			if len(matches) == 4 {
+				// this is a DSA line
+				// have we finished processing a DSA?
+				if currentDSA.name != "" {
+					if ctx.cveToDSA == nil {
+						ctx.cveToDSA = make(map[string][]dsa)
+					}
+					for _, cve := range currentDSA.cves {
+						ctx.cveToDSA[cve] = append(ctx.cveToDSA[cve], currentDSA)
+					}
+				}
+				currentDSA = dsa{name: matches[2], description: matches[3]}
+				currentDSA.date, err = time.Parse("02 Jan 2006", matches[1])
+				if err != nil {
+					log.Println("Error", err)
+					return xerrors.Errorf("failed parsing date:%s %w", matches[1], err)
+				}
+			} else if currentDSA.name != "" {
+				// this is a line about the current DSA
+				cveMatches := dsaCVEsLine.FindAllStringSubmatch(line, -1)
+				if len(cveMatches) > 0 {
+					for _, match := range cveMatches {
+						if match[1] != "" {
+							currentDSA.cves = append(currentDSA.cves, match[1])
+						}
+					}
+				} else {
+					matches := dsaPkgLine.FindStringSubmatch(line)
+					if len(matches) == 4 {
+						// ignore unsupported releases
+						if _, exists := ctx.oss[matches[1]]; !exists {
+							continue
+						}
+
+						currentDSA.packages = append(currentDSA.packages, pkg{
+							release: matches[1],
+							name:    matches[2],
+							version: matches[3],
+						})
+					}
+				}
+			}
+		}
+		dsaFile.Close() // nolint: errcheck
+	}
+	return nil
+}
+
+func (ctx *DebianSalsa) parseCVEs() error {
+	log.Println("Processing CVEs")
+	cveFile, err := os.Open("security-tracker/data/CVE/list")
+	if err != nil {
+		return xerrors.Errorf("failed opening CVE list: %w", err)
+	}
+	var currentCVE cve
+	scanner := bufio.NewScanner(cveFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := cveLine.FindStringSubmatch(line)
+		if len(matches) == 2 {
+			if currentCVE.name != "" {
+				err = ctx.processCVE(currentCVE)
+				if err != nil {
+					log.Println("Error", err)
+				}
+			}
+			currentCVE = cve{name: matches[1]}
+		} else if currentCVE.name != "" {
+			// this is a line about the current CVE
+			if notForUsLine.MatchString(line) {
+				currentCVE.notForUs = true
+				continue
+			} else if reservedLine.MatchString(line) {
+				currentCVE.reserved = true
+				continue
+			} else {
+				matches := noteLine.FindStringSubmatch(line)
+				if len(matches) == 2 {
+					currentCVE.notes = append(currentCVE.notes, matches[1])
+					continue
+				}
+				matches = packageLine.FindStringSubmatch(line)
+				if len(matches) == 5 {
+					currentCVE.packages = append(currentCVE.packages, pkg{
+						release:  matches[1],
+						name:     matches[2],
+						version:  matches[3],
+						severity: matches[4],
+					})
+				}
+			}
+		}
+	}
+	cveFile.Close() // nolint: errcheck
+	return nil
+}
+
+func (ctx *DebianSalsa) processCVE(cve cve) error {
+	// ignore NOT-FOR-US vulnerabilities
+	if cve.notForUs {
+		return nil
+	}
+	// ignore vulnerabilities that do not have IDs
+	if strings.HasSuffix(cve.name, "-XXXX") {
+		return nil
+	}
+	for _, p := range cve.packages {
+		// ignore releases not supported by the security tracker
+		if p.release != "" {
+			if _, exists := ctx.oss[p.release]; !exists {
+				continue
+			}
+		}
+		if p.release == "" {
+			p.release = "unstable"
+		}
+		if p.version == "<not-affected>" || p.version == "<removed>" {
+			continue
+		} else if p.version == "<unfixed>" || p.version == "<end-of-life>" {
+			// this vulnerability has not been fixed yet
+			p.version = ""
+		} else if p.version == "<no-dsa>" ||
+			p.version == "<ignored>" ||
+			p.version == "<postponed>" {
+			if p.version == "<ignored>" {
+				p.willNotFix = true
+			}
+			p.severityClassification = SeverityClassification[p.version]
+			p.statement = p.severity
+			p.version = ""
+			p.severity = "negligible"
+			p.classification = 1
+		} else if p.version == "<undetermined>" {
+			// package is _probably_ vulnerable, but the severity is unknown
+			p.severityClassification = SeverityClassification[p.version]
+			p.statement = p.severity
+			p.version = ""
+			p.severity = "unknown"
+			p.classification = 2
+		}
+		// remove bug numbers from severity
+		p.severity = bugNumber.ReplaceAllString(p.severity, "")
+		// by now, severity should be one of "unknown", "negligible",
+		// "low", "medium" or "high". If it's anything else, it's probably a note rather than a severity
+		if p.severity != "unknown" &&
+			p.severity != "unimportant" &&
+			p.severity != "negligible" &&
+			p.severity != "low" &&
+			p.severity != "medium" &&
+			p.severity != "high" {
+			if p.statement == "" {
+				p.statement = p.severity
+			}
+			p.severity = ""
+		}
+		// a package may have a vendor statement, but the CVE
+		// itself may also have notes, so let's add them too
+		// if they exist
+		var notes []string
+		if p.statement != "" {
+			notes = append(notes, p.statement)
+		}
+		if len(cve.notes) > 0 {
+			notes = append(notes, cve.notes...)
+		}
+		p.statement = strings.Join(notes, "\n")
+		seenRelease := false
+		// is this CVE part of a security advisory?
+		dsas, cveInDSA := ctx.cveToDSA[cve.name]
+		if cveInDSA {
+			for _, dsa := range dsas {
+				for _, dsaPkg := range dsa.packages {
+					if dsaPkg.name == p.name {
+						if _, exists := ctx.oss[dsaPkg.release]; !exists {
+							log.Println("Unknown OS, skipping", dsaPkg.release)
+							break
+						}
+						if dsaPkg.release == p.release {
+							seenRelease = true
+						}
+						if ctx.PackageData[dsaPkg.name] == nil {
+							releaseDetails := ReleaseDetails{
+								FixVersion: dsaPkg.version,
+								Severity:   p.severity,
+								Statement:  p.statement,
+								SecurityAdvisory: map[string]SecurityAdvisory{dsa.name: {
+									PublishDate: dsa.date.String(),
+									Description: dsa.description,
+								}},
+								ClassificationID: p.classification,
+							}
+							cveRel := CVERelease{Description: p.statement, Releases: map[string]ReleaseDetails{dsaPkg.release: releaseDetails}}
+							ctx.PackageData[dsaPkg.name] = map[string]CVERelease{cve.name: cveRel}
+						} else {
+							if cveRelease, cveInMap := ctx.PackageData[dsaPkg.name][cve.name]; cveInMap {
+								if _, isRelInMap := cveRelease.Releases[dsaPkg.release]; !isRelInMap {
+									cveRelease.Releases[dsaPkg.release] = ReleaseDetails{
+										FixVersion: dsaPkg.version,
+										Severity:   p.severity,
+										Statement:  p.statement,
+										SecurityAdvisory: map[string]SecurityAdvisory{dsa.name: {
+											PublishDate: dsa.date.String(),
+											Description: dsa.description,
+										}},
+										ClassificationID: p.classification,
+									}
+									ctx.PackageData[dsaPkg.name][cve.name] = cveRelease
+								}
+							} else {
+								newRelDetail := ReleaseDetails{
+									FixVersion: dsaPkg.version,
+									Severity:   p.severity,
+									Statement:  p.statement,
+									SecurityAdvisory: map[string]SecurityAdvisory{dsa.name: {
+										PublishDate: dsa.date.String(),
+										Description: dsa.description,
+									}},
+									ClassificationID: p.classification}
+								cveRel := CVERelease{Description: p.statement, Releases: map[string]ReleaseDetails{dsaPkg.release: newRelDetail}}
+								ctx.PackageData[dsaPkg.name][cve.name] = cveRel
+							}
+						}
+					}
+				}
+			}
+		}
+		if !seenRelease {
+			if _, exists := ctx.oss[p.release]; !exists {
+				continue
+			}
+			if ctx.PackageData[p.name] == nil {
+				releaseDetails := ReleaseDetails{
+					FixVersion:             p.version,
+					Severity:               p.severity,
+					Statement:              p.statement,
+					WillNotFix:             p.willNotFix,
+					ClassificationID:       p.classification,
+					SeverityClassification: p.severityClassification,
+				}
+				cveRel := CVERelease{Description: p.statement, Releases: map[string]ReleaseDetails{p.release: releaseDetails}}
+				ctx.PackageData[p.name] = map[string]CVERelease{cve.name: cveRel}
+			} else {
+				if cveRelease, cveInMap := ctx.PackageData[p.name][cve.name]; cveInMap {
+					cveRelease.Releases[p.release] = ReleaseDetails{
+						FixVersion:             p.version,
+						Severity:               p.severity,
+						Statement:              p.statement,
+						WillNotFix:             p.willNotFix,
+						ClassificationID:       p.classification,
+						SeverityClassification: p.severityClassification,
+					}
+					ctx.PackageData[p.name][cve.name] = cveRelease
+				} else {
+					newRelDetail := ReleaseDetails{
+						FixVersion:             p.version,
+						Severity:               p.severity,
+						Statement:              p.statement,
+						WillNotFix:             p.willNotFix,
+						ClassificationID:       p.classification,
+						SeverityClassification: p.severityClassification}
+					cveRel := CVERelease{Description: p.statement, Releases: map[string]ReleaseDetails{p.release: newRelDetail}}
+					ctx.PackageData[p.name][cve.name] = cveRel
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/debian/salsa/debian_test.go
+++ b/debian/salsa/debian_test.go
@@ -1,0 +1,157 @@
+package salsa
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
+)
+
+func TestDebianSalsa_getReleases(t *testing.T) {
+	type fields struct {
+		VulnListDir    string
+		oss            map[string]string
+		cveToDSA       map[string][]dsa
+		PackageData    map[string]map[string]CVERelease
+		cloneDirectory string
+	}
+	releaseFields := fields{
+		VulnListDir:    "testdata/got",
+		oss:            nil,
+		cveToDSA:       nil,
+		PackageData:    make(map[string]map[string]CVERelease),
+		cloneDirectory: "testdata/fixtures",
+	}
+	ossData := map[string]string{
+		"wheezy":   "7",
+		"jessie":   "8",
+		"stretch":  "9",
+		"buster":   "10",
+		"bullseye": "11",
+		"sid":      "unstable"}
+	dsaDate, err := time.Parse("02 Jan 2006", "10 Jun 2021")
+	assert.NoError(t, err, "Date parsing error")
+	dsa4930 := dsa{
+		name:        "DSA-4930-1",
+		date:        dsaDate,
+		description: "libwebp - security update",
+		cves:        []string{"CVE-2018-25009", "CVE-2018-25010"},
+		packages:    []pkg{{release: "buster", name: "libwebp", version: "0.6.1-2+deb10u1", severity: "", statement: "", willNotFix: false, classification: 0, severityClassification: ""}},
+	}
+
+	dsaDate, err = time.Parse("02 Jan 2006", "30 Jul 2002")
+	assert.NoError(t, err, "Date parsing error")
+	dsa136 := dsa{
+		name:        "DSA-136",
+		date:        dsaDate,
+		description: "openssl - multiple remote exploits",
+		cves:        []string{"CVE-2002-0655", "CVE-2002-0656"},
+		packages:    nil,
+	}
+
+	dsaDate, err = time.Parse("02 Jan 2006", "02 Jul 2002")
+	assert.NoError(t, err, "Date parsing error")
+	dsa135 := dsa{
+		name:        "DSA-135",
+		date:        dsaDate,
+		description: "libapache-mod-ssl -- buffer overflow / DoS",
+		cves:        []string{"CVE-2002-0653"},
+		packages:    nil,
+	}
+
+	dsaDate, err = time.Parse("02 Jan 2006", "09 Jun 2021")
+	assert.NoError(t, err, "Date parsing error")
+
+	dla2681 := dsa{
+		name:        "DLA-2681-1",
+		date:        dsaDate,
+		description: "eterm - security update",
+		cves:        []string{"CVE-2021-33477"},
+		packages:    []pkg{{release: "stretch", name: "eterm", version: "0.9.6-5+deb9u1", severity: "", statement: "", willNotFix: false, classification: 0, severityClassification: ""}},
+	}
+
+	dsaDate, err = time.Parse("02 Jan 2006", "02 Jun 2014")
+	assert.NoError(t, err, "Date parsing error")
+	dla0001 := dsa{
+		name:        "DLA-0001-1",
+		date:        dsaDate,
+		description: "gnutls26 - security update",
+		cves:        []string{"CVE-2014-3466"},
+		packages:    nil,
+	}
+
+	wantCVEtoDSAData := map[string][]dsa{"CVE-2018-25009": {dsa4930}, "CVE-2018-25010": {dsa4930}, "CVE-2002-0655": {dsa136}, "CVE-2002-0656": {dsa136},
+		"CVE-2021-33477": {dla2681}, "CVE-2002-0653": {dsa135}, "CVE-2014-3466": {dla0001}}
+
+	tests := []struct {
+		name         string
+		fields       fields
+		wantErr      bool
+		wantOss      map[string]string
+		wantCVEtoDSA map[string][]dsa
+	}{
+		{name: "All functions", fields: releaseFields, wantErr: false, wantOss: ossData, wantCVEtoDSA: wantCVEtoDSAData},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			debianCtx := &DebianSalsa{
+				VulnListDir:    tt.fields.VulnListDir,
+				oss:            tt.fields.oss,
+				cveToDSA:       tt.fields.cveToDSA,
+				PackageData:    tt.fields.PackageData,
+				cloneDirectory: tt.fields.cloneDirectory,
+			}
+			if err := debianCtx.getReleases(); (err != nil) != tt.wantErr {
+				t.Errorf("getReleases() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.wantOss, debianCtx.oss) {
+				t.Errorf("oss = %v, wantoss %v", debianCtx.oss, tt.wantOss)
+			}
+			// Test DSA
+			if err := debianCtx.parseDSAs(); (err != nil) != tt.wantErr {
+				t.Errorf("parseDSAs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.wantCVEtoDSA, debianCtx.cveToDSA) {
+				t.Errorf("cveToDSA = %v, wantCVEtoDSA %v", debianCtx.cveToDSA, tt.wantCVEtoDSA)
+			}
+			if err := debianCtx.parseCVEs(); (err != nil) != tt.wantErr {
+				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := debianCtx.writePackages(); (err != nil) != tt.wantErr {
+				t.Errorf("writePackages() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			dir := filepath.Join(debianCtx.VulnListDir, "debian-salsa")
+			assert.NoError(t, err, "failed to create temp dir")
+			defer os.RemoveAll(debianCtx.VulnListDir)
+			err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return xerrors.Errorf("walk error: %w", err)
+				}
+				if info.IsDir() {
+					return nil
+				}
+				paths := strings.Split(path, string(os.PathSeparator))
+				p := filepath.Join(paths[len(paths)-2:]...)
+				golden := filepath.Join("testdata", "golden", "debian-salsa", p+".golden")
+
+				want, err := ioutil.ReadFile(golden)
+				assert.NoError(t, err, "failed to open the golden file")
+
+				got, err := ioutil.ReadFile(path)
+				assert.NoError(t, err, "failed to open the result file")
+
+				if match := assert.Equal(t, string(want), string(got)); !match {
+					t.Errorf("want file = %v, got %v", want, got)
+				}
+
+				return nil
+			})
+		})
+	}
+}

--- a/debian/salsa/testdata/fixtures/data/CVE/list
+++ b/debian/salsa/testdata/fixtures/data/CVE/list
@@ -1,0 +1,24 @@
+CVE-2020-24489 (Incomplete cleanup in some Intel(R) VT-d products may allow an authent ...)
+	{DSA-4934-1}
+	- intel-microcode 3.20210608.1 (bug #989615)
+	NOTE: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210608
+	NOTE: https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00442.html
+CVE-2014-3466 (Buffer overflow in the read_server_hello function in lib/gnutls_handsh ...)
+	{DSA-2944-1 DLA-0001-1}
+	- gnutls26 2.12.23-16
+	- gnutls28 3.2.15-1
+	[squeeze] - gnutls26 2.8.6-1+squeeze4
+	NOTE: http://radare.today/technical-analysis-of-the-gnutls-hello-vulnerability/
+CVE-2018-25009 (A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds ...)
+	{DSA-4930-1 DLA-2677-1}
+	- libwebp 0.6.1-2.1
+	NOTE: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9100
+	NOTE: https://chromium.googlesource.com/webm/libwebp/+/95fd65070662e01cc9170c4444f5c0859a710097%5E%21/
+CVE-2021-30499 (A flaw was found in libcaca. A buffer overflow of export.c in function ...)
+	- libcaca <unfixed> (bug #987278)
+	[bullseye] - libcaca <no-dsa> (Minor issue)
+	[buster] - libcaca <no-dsa> (Minor issue)
+	[stretch] - libcaca <postponed> (Minor issue; can be fixed in next update)
+	NOTE: https://github.com/cacalabs/libcaca/issues/54
+CVE-2021-30492
+	RESERVED

--- a/debian/salsa/testdata/fixtures/data/DLA/list
+++ b/debian/salsa/testdata/fixtures/data/DLA/list
@@ -1,0 +1,8 @@
+[09 Jun 2021] DLA-2681-1 eterm - security update
+	{CVE-2021-33477}
+	[stretch] - eterm 0.9.6-5+deb9u1
+[27 Apr 2021] DLA-2644-1 gst-libav1.0 - security update
+	[stretch] - gst-libav1.0 1.10.4-1+deb9u1
+[02 Jun 2014] DLA-0001-1 gnutls26 - security update
+	{CVE-2014-3466}
+	[squeeze] - gnutls26 2.8.6-1+squeeze4

--- a/debian/salsa/testdata/fixtures/data/DSA/list
+++ b/debian/salsa/testdata/fixtures/data/DSA/list
@@ -1,0 +1,12 @@
+[10 Jun 2021] DSA-4930-1 libwebp - security update
+	{CVE-2018-25009 CVE-2018-25010}
+	[buster] - libwebp 0.6.1-2+deb10u1
+[30 Jul 2002] DSA-136 openssl - multiple remote exploits
+	{CVE-2002-0655 CVE-2002-0656}
+	[woody] - openssl094 0.9.4-6.woody.2
+	[woody] - openssl095 0.9.5a-6.woody.1
+	[woody] - openssl 0.9.6c-2.woody.1
+[02 Jul 2002] DSA-135 libapache-mod-ssl -- buffer overflow / DoS
+	{CVE-2002-0653}
+	[woody] - libapache-mod-ssl 2.8.9-2
+

--- a/debian/salsa/testdata/fixtures/static/distributions.json
+++ b/debian/salsa/testdata/fixtures/static/distributions.json
@@ -1,0 +1,42 @@
+{
+  "wheezy": {
+    "major-version": "7",
+    "support": "end-of-life",
+    "contact": ""
+  },
+  "jessie": {
+    "major-version": "8",
+    "support": "end-of-life",
+    "contact": ""
+  },
+  "stretch": {
+    "major-version": "9",
+    "support": "lts",
+    "contact": "debian-lts@lists.debian.org"
+  },
+  "buster": {
+    "major-version": "10",
+    "support": "security",
+    "contact": "team@security.debian.org"
+  },
+  "bullseye": {
+    "major-version": "11",
+    "support": "none",
+    "contact": ""
+  },
+  "bookworm": {
+    "major-version": "12",
+    "support": "none",
+    "contact": ""
+  },
+  "trixie": {
+    "major-version": "13",
+    "support": "none",
+    "contact": ""
+  },
+  "sid": {
+    "major-version": "",
+    "support": "none",
+    "contact": ""
+  }
+}

--- a/debian/salsa/testdata/golden/debian-salsa/gnutls26/CVE-2014-3466.json.golden
+++ b/debian/salsa/testdata/golden/debian-salsa/gnutls26/CVE-2014-3466.json.golden
@@ -1,0 +1,9 @@
+{
+  "description": "",
+  "releases": {
+    "sid": {
+      "fix_version": "2.12.23-16",
+      "statement": "http://radare.today/technical-analysis-of-the-gnutls-hello-vulnerability/"
+    }
+  }
+}

--- a/debian/salsa/testdata/golden/debian-salsa/gnutls28/CVE-2014-3466.json.golden
+++ b/debian/salsa/testdata/golden/debian-salsa/gnutls28/CVE-2014-3466.json.golden
@@ -1,0 +1,9 @@
+{
+  "description": "",
+  "releases": {
+    "sid": {
+      "fix_version": "3.2.15-1",
+      "statement": "http://radare.today/technical-analysis-of-the-gnutls-hello-vulnerability/"
+    }
+  }
+}

--- a/debian/salsa/testdata/golden/debian-salsa/intel-microcode/CVE-2020-24489.json.golden
+++ b/debian/salsa/testdata/golden/debian-salsa/intel-microcode/CVE-2020-24489.json.golden
@@ -1,0 +1,9 @@
+{
+  "description": "",
+  "releases": {
+    "sid": {
+      "fix_version": "3.20210608.1",
+      "statement": "https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210608\nhttps://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00442.html"
+    }
+  }
+}

--- a/debian/salsa/testdata/golden/debian-salsa/libcaca/CVE-2021-30499.json.golden
+++ b/debian/salsa/testdata/golden/debian-salsa/libcaca/CVE-2021-30499.json.golden
@@ -1,0 +1,26 @@
+{
+  "description": "",
+  "releases": {
+    "bullseye": {
+      "severity": "negligible",
+      "statement": "Minor issue\nhttps://github.com/cacalabs/libcaca/issues/54",
+      "classification_id": 1,
+      "severity_classification": "Fix Version: No DSA"
+    },
+    "buster": {
+      "severity": "negligible",
+      "statement": "Minor issue\nhttps://github.com/cacalabs/libcaca/issues/54",
+      "classification_id": 1,
+      "severity_classification": "Fix Version: No DSA"
+    },
+    "sid": {
+      "statement": "https://github.com/cacalabs/libcaca/issues/54"
+    },
+    "stretch": {
+      "severity": "negligible",
+      "statement": "Minor issue; can be fixed in next update\nhttps://github.com/cacalabs/libcaca/issues/54",
+      "classification_id": 1,
+      "severity_classification": "Fix Version: Postponed"
+    }
+  }
+}

--- a/debian/salsa/testdata/golden/debian-salsa/libwebp/CVE-2018-25009.json.golden
+++ b/debian/salsa/testdata/golden/debian-salsa/libwebp/CVE-2018-25009.json.golden
@@ -1,0 +1,17 @@
+{
+  "description": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9100\nhttps://chromium.googlesource.com/webm/libwebp/+/95fd65070662e01cc9170c4444f5c0859a710097%5E%21/",
+  "releases": {
+    "buster": {
+      "security_advisory": {
+        "DSA-4930-1": {
+          "description": "libwebp - security update",
+          "publish_date": "2021-06-10 00:00:00 +0000 UTC"
+        }
+      }
+    },
+    "sid": {
+      "fix_version": "0.6.1-2.1",
+      "statement": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9100\nhttps://chromium.googlesource.com/webm/libwebp/+/95fd65070662e01cc9170c4444f5c0859a710097%5E%21/"
+    }
+  }
+}

--- a/git/git.go
+++ b/git/git.go
@@ -20,7 +20,7 @@ type Operations interface {
 type Config struct {
 }
 
-func (gc Config) CloneOrPull(url, repoPath, branch string, debug bool) (map[string]struct{}, error) {
+func (gc Config) CloneOrPull(url, repoPath, branch string, debug bool, isFetchAll bool) (map[string]struct{}, error) {
 	exists, err := utils.Exists(filepath.Join(repoPath, ".git"))
 	if err != nil {
 		return nil, err
@@ -49,9 +49,10 @@ func (gc Config) CloneOrPull(url, repoPath, branch string, debug bool) (map[stri
 		if err := clone(url, repoPath, branch); err != nil {
 			return nil, err
 		}
-
-		if err := fetchAll(repoPath); err != nil {
-			return nil, err
+		if isFetchAll {
+			if err := fetchAll(repoPath); err != nil {
+				return nil, err
+			}
 		}
 		err = filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
 			if info.IsDir() {

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -44,7 +44,7 @@ func (u Updater) Update() error {
 
 	gc := git.Config{}
 	dir := filepath.Join(u.cacheDir, gladDir)
-	if _, err := gc.CloneOrPull(repoURL, dir, "main", false); err != nil {
+	if _, err := gc.CloneOrPull(repoURL, dir, "main", false, true); err != nil {
 		return xerrors.Errorf("failed to clone or pull: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func run() error {
 
 	log.Printf("target repository is %s/%s\n", repoOwner, repoName)
 
-	if _, err := gc.CloneOrPull(url, utils.VulnListDir(), "main", debug); err != nil {
+	if _, err := gc.CloneOrPull(url, utils.VulnListDir(), "main", debug, true); err != nil {
 		return xerrors.Errorf("clone or pull error: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aquasecurity/vuln-list-update/debian/salsa"
+
 	githubql "github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 	"golang.org/x/xerrors"
@@ -41,7 +43,7 @@ const (
 
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, redhat, redhat-oval, "+
-		"debian, debian-oval, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe)")
+		"debian, debian-oval, debian-salsa, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe)")
 	years = flag.String("years", "", "update years (only redhat)")
 )
 
@@ -110,6 +112,12 @@ func run() error {
 	case "debian":
 		dc := tracker.NewClient()
 		if err := dc.Update(); err != nil {
+			return xerrors.Errorf("error in Debian update: %w", err)
+		}
+		commitMsg = "Debian Security Bug Tracker"
+	case "debian-salsa":
+		salsaCli := salsa.NewClient()
+		if err := salsaCli.Update(); err != nil {
 			return xerrors.Errorf("error in Debian update: %w", err)
 		}
 		commitMsg = "Debian Security Bug Tracker"

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -77,7 +77,7 @@ func Update() error {
 	gc := git.Config{}
 	dir := filepath.Join(utils.CacheDir(), cveTrackerDir)
 	for _, url := range repoURLs {
-		_, err = gc.CloneOrPull(url, dir, "master", false)
+		_, err = gc.CloneOrPull(url, dir, "master", false, true)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
1. Capture security Advisory DSA and DLA
2. Relation between security advisory and CVE
3. Support EOL version in trivy. Currently Trivy supports CVEs which have fixed versions. But we should support open CVEs also.
4. Capture vendor severity
5. Capture will not fix CVEs