### PR TITLE
chore: add Red Hat Security Data API 2022

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -134,5 +134,5 @@ jobs:
       run: ./vuln-list-update -target redhat -years 2018
 
     - if: always()
-      name: Red Hat Security Data API 2019-2021
-      run: ./vuln-list-update -target redhat -years 2019,2020,2021
+      name: Red Hat Security Data API 2019-2022
+      run: ./vuln-list-update -target redhat -years 2019,2020,2021,2022


### PR DESCRIPTION
The year 2022 has been added to the Red Hat Security Data API part of update.yml.
```console
$ VULN_LIST_DEBUG=1  ./vuln-list-update -target redhat -years 2022
2022/01/07 14:10:18 target repository is aquasecurity/vuln-list
2022/01/07 14:10:18 Skip git pull
2022/01/07 14:10:18 Fetching RedHat: year 2022
2022/01/07 14:10:18 page 1
2022/01/07 14:10:19 page 2
 7 / 7 [============================================================] 100.00% 0s
```