### PR TITLE
feat(glad): add ability to set custom repository uri

### DIFF
--- a/glad/glad.go
+++ b/glad/glad.go
@@ -39,12 +39,18 @@ func NewUpdater() Updater {
 	}
 }
 
-func (u Updater) Update() error {
+func (u Updater) Update(alternativeRepoURL string) error {
 	log.Print("Fetching GitLab Advisory Database (advisories-community)")
 
 	gc := git.Config{}
 	dir := filepath.Join(u.cacheDir, gladDir)
-	if _, err := gc.CloneOrPull(repoURL, dir, "main", false); err != nil {
+	defaultOrAlternativeRepoURL := repoURL
+
+	if len(alternativeRepoURL) > 0 {
+		defaultOrAlternativeRepoURL = alternativeRepoURL
+	}
+
+	if _, err := gc.CloneOrPull(defaultOrAlternativeRepoURL, dir, "main", false); err != nil {
 		return xerrors.Errorf("failed to clone or pull: %w", err)
 	}
 

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -27,20 +27,24 @@ var (
 )
 
 type Updater struct {
-	vulnListDir string
-	cacheDir    string
-	appFs       afero.Fs
+	alternativeRepoBranch string
+	alternativeRepoURL    string
+	vulnListDir           string
+	cacheDir              string
+	appFs                 afero.Fs
 }
 
-func NewUpdater() Updater {
+func NewUpdater(alternativeRepoURL string, alternativeRepoBranch string) Updater {
 	return Updater{
-		vulnListDir: utils.VulnListDir(),
-		cacheDir:    utils.CacheDir(),
-		appFs:       afero.NewOsFs(),
+		alternativeRepoBranch: alternativeRepoBranch,
+		alternativeRepoURL:    alternativeRepoURL,
+		vulnListDir:           utils.VulnListDir(),
+		cacheDir:              utils.CacheDir(),
+		appFs:                 afero.NewOsFs(),
 	}
 }
 
-func (u Updater) Update(alternativeRepoURL string, alternativeRepoBranch string) error {
+func (u Updater) Update() error {
 	log.Print("Fetching GitLab Advisory Database (advisories-community)")
 
 	gc := git.Config{}
@@ -48,12 +52,12 @@ func (u Updater) Update(alternativeRepoURL string, alternativeRepoBranch string)
 	defaultOrAlternativeRepoURL := repoURL
 	defaultOrAlternativeRepoBranch := repoBranch
 
-	if len(alternativeRepoURL) > 0 {
-		defaultOrAlternativeRepoURL = alternativeRepoURL
+	if len(u.alternativeRepoURL) > 0 {
+		defaultOrAlternativeRepoURL = u.alternativeRepoURL
 	}
 
-	if len(alternativeRepoBranch) > 0 {
-		defaultOrAlternativeRepoBranch = alternativeRepoBranch
+	if len(u.alternativeRepoBranch) > 0 {
+		defaultOrAlternativeRepoBranch = u.alternativeRepoBranch
 	}
 
 	if _, err := gc.CloneOrPull(defaultOrAlternativeRepoURL, dir, defaultOrAlternativeRepoBranch, false); err != nil {

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	repoURL = "https://gitlab.com/gitlab-org/advisories-community.git"
-	gladDir = "glad" // GitLab Advisory Database
+	repoURL    = "https://gitlab.com/gitlab-org/advisories-community.git"
+	repoBranch = "master"
+	gladDir    = "glad" // GitLab Advisory Database
 )
 
 var (
@@ -39,18 +40,23 @@ func NewUpdater() Updater {
 	}
 }
 
-func (u Updater) Update(alternativeRepoURL string) error {
+func (u Updater) Update(alternativeRepoURL string, alternativeRepoBranch string) error {
 	log.Print("Fetching GitLab Advisory Database (advisories-community)")
 
 	gc := git.Config{}
 	dir := filepath.Join(u.cacheDir, gladDir)
 	defaultOrAlternativeRepoURL := repoURL
+	defaultOrAlternativeRepoBranch := repoBranch
 
 	if len(alternativeRepoURL) > 0 {
 		defaultOrAlternativeRepoURL = alternativeRepoURL
 	}
 
-	if _, err := gc.CloneOrPull(defaultOrAlternativeRepoURL, dir, "main", false); err != nil {
+	if len(alternativeRepoBranch) > 0 {
+		defaultOrAlternativeRepoBranch = alternativeRepoBranch
+	}
+
+	if _, err := gc.CloneOrPull(defaultOrAlternativeRepoURL, dir, defaultOrAlternativeRepoBranch, false); err != nil {
 		return xerrors.Errorf("failed to clone or pull: %w", err)
 	}
 

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	repoURL    = "https://gitlab.com/gitlab-org/advisories-community.git"
-	repoBranch = "master"
+	repoBranch = "main"
 	gladDir    = "glad" // GitLab Advisory Database
 )
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ const (
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
 		"debian, debian-oval, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, go-vulndb, mariner)")
-	years = flag.String("years", "", "update years (only redhat)")
+	years     = flag.String("years", "", "update years (only redhat)")
+	targetUri = flag.String("target-uri", "", "alternative repository URI (only glad)")
 )
 
 func main() {
@@ -175,7 +176,7 @@ func run() error {
 		commitMsg = "GitHub Security Advisory"
 	case "glad":
 		gu := glad.NewUpdater()
-		if err := gu.Update(); err != nil {
+		if err := gu.Update(*targetUri); err != nil {
 			return xerrors.Errorf("GitLab Advisory Database update error: %w", err)
 		}
 		commitMsg = "GitLab Advisory Database"

--- a/main.go
+++ b/main.go
@@ -176,8 +176,8 @@ func run() error {
 		}
 		commitMsg = "GitHub Security Advisory"
 	case "glad":
-		gu := glad.NewUpdater()
-		if err := gu.Update(*targetUri, *targetBranch); err != nil {
+		gu := glad.NewUpdater(*targetUri, *targetBranch)
+		if err := gu.Update(); err != nil {
 			return xerrors.Errorf("GitLab Advisory Database update error: %w", err)
 		}
 		commitMsg = "GitLab Advisory Database"

--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ const (
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
 		"debian, debian-oval, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, go-vulndb, mariner)")
-	years     = flag.String("years", "", "update years (only redhat)")
-	targetUri = flag.String("target-uri", "", "alternative repository URI (only glad)")
+	years        = flag.String("years", "", "update years (only redhat)")
+	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
+	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
 )
 
 func main() {
@@ -176,7 +177,7 @@ func run() error {
 		commitMsg = "GitHub Security Advisory"
 	case "glad":
 		gu := glad.NewUpdater()
-		if err := gu.Update(*targetUri); err != nil {
+		if err := gu.Update(*targetUri, *targetBranch); err != nil {
 			return xerrors.Errorf("GitLab Advisory Database update error: %w", err)
 		}
 		commitMsg = "GitLab Advisory Database"


### PR DESCRIPTION
## Background

By default we are building `vuln-list` for `glad` by using https://gitlab.com/gitlab-org/advisories-community database, we would like to allow customizing this, so users can build their own databases based on https://gitlab.com/gitlab-org/advisories-community. 

## Usage

Example:
```
vuln-list-update -target glad -target-uri "https://gitlab.com/mparuszewski/custom-advisories-database" -target-branch "main"
```

Both parameters `-target-uri` and `-target-branch` can be easily reused for other targets (ie. alpine, mariner, etc.).