### PR TITLE
fix(ghsa): added nil check for received nodes

### DIFF
--- a/ghsa/ghsa.go
+++ b/ghsa/ghsa.go
@@ -93,6 +93,10 @@ func (c Config) update(ecosystem SecurityAdvisoryEcosystem) error {
 
 	ghsaJsonMap := make(map[string]GithubSecurityAdvisoryJson)
 	for _, ghsa := range ghsas {
+		// skip bad ghsa
+		if ghsa.Package.Name == "" {
+			continue
+		}
 		ghsa.Package.Name = strings.TrimSpace(ghsa.Package.Name)
 
 		ghsaJson, ok := ghsaJsonMap[ghsa.Advisory.GhsaId+ghsa.Package.Name]
@@ -151,11 +155,14 @@ func (c Config) fetchGithubSecurityAdvisories(ecosystem SecurityAdvisoryEcosyste
 			}
 
 			err = c.client.Query(context.Background(), &getVulnerabilitiesQuery, variables)
-			if err == nil {
+			if err == nil || len(getVulnerabilitiesQuery.Nodes) > 0 {
 				break
 			}
 		}
-		if err != nil {
+		// GitHub GraphQL API may return error and one of nodes == nil
+		// We must write other nodes.
+		// Bad node will be skipped in 'update' function
+		if err != nil && len(getVulnerabilitiesQuery.Nodes) == 0 {
 			return nil, xerrors.Errorf("graphql api error: %w", err)
 		}
 

--- a/ghsa/ghsa_test.go
+++ b/ghsa/ghsa_test.go
@@ -108,6 +108,66 @@ func TestConfig_Update(t *testing.T) {
 			},
 		},
 		{
+			name:           "positive test with one nil node",
+			appFs:          afero.NewMemMapFs(),
+			inputEcosystem: Composer,
+			goldenFiles: map[string]string{
+				"/tmp/ghsa/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json": "testdata/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json",
+			},
+			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
+				githubql.String(""): {
+					SecurityVulnerabilities: SecurityVulnerabilities{
+						Nodes: []GithubSecurityAdvisory{
+							{
+								Severity:  "LOW",
+								UpdatedAt: "2020-01-24T21:15:59Z",
+								Package: Package{
+									Ecosystem: "COMPOSER",
+									Name:      "simplesamlphp/simplesamlphp",
+								},
+								Advisory: Advisory{
+									DatabaseId: 1883,
+									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJyM3YtcTl4My03ZzQ2",
+									GhsaId:     "GHSA-2r3v-q9x3-7g46",
+									References: []Reference{
+										{
+											Url: "https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-2r3v-q9x3-7g46",
+										},
+									},
+									Identifiers: []Identifier{
+										{
+											Type:  "GHSA",
+											Value: "GHSA-2r3v-q9x3-7g46",
+										},
+									},
+									Description: "### Background\nSeveral scripts part of SimpleSAMLphp display a web page with links obtained from the request parameters. This allows us to enhance usability, as the users are presented with links they can follow after completing a certain action, like logging out.\n\n### Description\nThe following scripts were not checking the URLs obtained via the HTTP request before displaying them as the target of links that the user may click on:\n\n- `www/logout.php`\n- `modules/core/www/no_cookie.php`\n\nThe issue allowed attackers to display links targeting a malicious website inside a trusted site running SimpleSAMLphp, due to the lack of security checks involving the `link_href` and `retryURL` HTTP parameters, respectively. The issue was resolved by including a verification of the URLs received in the request against a white list of websites specified in the `trusted.url.domains` configuration option.\n\n### Affected versions\nAll SimpleSAMLphp versions prior to 1.14.4.\n\n### Impact\nA remote attacker could craft a link pointing to a trusted website running SimpleSAMLphp, including a parameter pointing to a malicious website, and try to fool the victim into visiting that website by clicking on a link in the page presented by SimpleSAMLphp.\n\n### Resolution\nUpgrade to the latest version.\n\n### Credit\nThis security issue was discovered and reported by John Page (hyp3rlinx).",
+									Origin:      "UNSPECIFIED",
+									PublishedAt: "2020-01-24T21:27:16Z",
+									Severity:    "LOW",
+									Summary:     "Low severity vulnerability that affects simplesamlphp/simplesamlphp",
+									UpdatedAt:   "2020-01-24T21:27:17Z",
+									WithdrawnAt: "",
+									CVSS: GithubCVSS{
+										Score:        3.7,
+										VectorString: "3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+									},
+								},
+								FirstPatchedVersion: FirstPatchedVersion{
+									Identifier: "1.14.4",
+								},
+								VulnerableVersionRange: "\u003c 1.14.4",
+							},
+							{}, // nil node
+						},
+						PageInfo: PageInfo{
+							EndCursor:   githubql.String(""),
+							HasNextPage: false,
+						},
+					},
+				},
+			},
+		},
+		{
 			name:           "positive test multi nodes",
 			appFs:          afero.NewMemMapFs(),
 			inputEcosystem: Maven,


### PR DESCRIPTION
## Description
GitHub GraphQL API may return error and one of nodes is empty
Added skip "bad" nodes.
See more: github/advisory-database#221