### PR TITLE
Integrate support for custom types

### DIFF
--- a/glad/glad.go
+++ b/glad/glad.go
@@ -34,7 +34,12 @@ type Updater struct {
 	appFs                 afero.Fs
 }
 
-func NewUpdater(alternativeRepoURL string, alternativeRepoBranch string) Updater {
+func NewUpdater(alternativeRepoURL string, alternativeRepoBranch string, customTypes string) Updater {
+	if len(customTypes) > 0 {
+		customTypes := strings.Split(customTypes, ",")
+		supportedTypes = append(supportedTypes, customTypes...)
+	}
+
 	return Updater{
 		alternativeRepoBranch: alternativeRepoBranch,
 		alternativeRepoURL:    alternativeRepoURL,

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	years        = flag.String("years", "", "update years (only redhat)")
 	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
 	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
+	customTypes =  flag.String("custom-types", "", "additional (comma-separated list) of custom package types (only glad)")
 )
 
 func main() {
@@ -176,7 +177,7 @@ func run() error {
 		}
 		commitMsg = "GitHub Security Advisory"
 	case "glad":
-		gu := glad.NewUpdater(*targetUri, *targetBranch)
+		gu := glad.NewUpdater(*targetUri, *targetBranch, *customTypes)
 		if err := gu.Update(); err != nil {
 			return xerrors.Errorf("GitLab Advisory Database update error: %w", err)
 		}


### PR DESCRIPTION
The changes introduced in this MR make it possible to specify custom types. This is useful for databases following that are based on the https://gitlab.com/gitlab-org/security-products/gemnasium-db format but support additional packages.