### PR TITLE
feat(glad): add parse for identifiers field

### DIFF
--- a/glad/glad.go
+++ b/glad/glad.go
@@ -166,9 +166,9 @@ func updateIdentifiers(basicIdentifier string, basicIdentifiers []string) string
 	// If an advisory doesn't have CVE-ID but there is GHSA-ID, we use GHSA-ID
 	if !strings.HasPrefix(updated, "CVE") {
 		for i := range basicIdentifiers {
-			if strings.HasPrefix(basicIdentifiers[i], "GHSA") {
-				updated = basicIdentifiers[i]
-				break
+			if ident := strings.ToUpper(basicIdentifiers[i]); strings.HasPrefix(ident, "GHSA") {
+				// return no uppercase string because GHSA id contains small letters (eg GHSA-qq97-vm5h-rrhg)
+				return basicIdentifiers[i]
 			}
 		}
 	}

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -64,6 +64,11 @@ func (u Updater) Update() error {
 		return xerrors.Errorf("failed to clone or pull: %w", err)
 	}
 
+	log.Println("Removing old glad files...")
+	if err := os.RemoveAll(filepath.Join(u.vulnListDir, gladDir)); err != nil {
+		xerrors.Errorf("can't remove a folder with old files %s/%s: %w", u.vulnListDir, gladDir, err)
+	}
+
 	log.Println("Walking glad...")
 	for _, target := range supportedTypes {
 		targetDir := filepath.Join(dir, target)

--- a/glad/glad_test.go
+++ b/glad/glad_test.go
@@ -26,7 +26,7 @@ func TestUpdater_WalkDir(t *testing.T) {
 		{
 			name:          "happy path",
 			rootDir:       "testdata/happy",
-			wantFileCount: 4,
+			wantFileCount: 5,
 		},
 		{
 			name:    "sad path",

--- a/glad/testdata/golden/glad/go/github.com/docker/distribution/GHSA-qq97-vm5h-rrhg.json
+++ b/glad/testdata/golden/glad/go/github.com/docker/distribution/GHSA-qq97-vm5h-rrhg.json
@@ -3,7 +3,7 @@
   "PackageSlug": "go/github.com/docker/distribution",
   "Title": "OCI Manifest Type Confusion Issue",
   "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",
-  "Date": "2022-02-11",
+  "Date": "2022-04-19",
   "Pubdate": "2022-02-08",
   "AffectedRange": "\u003cv2.8.0",
   "FixedVersions": [

--- a/glad/testdata/golden/glad/go/github.com/docker/distribution/GHSA-qq97-vm5h-rrhg.json
+++ b/glad/testdata/golden/glad/go/github.com/docker/distribution/GHSA-qq97-vm5h-rrhg.json
@@ -1,0 +1,24 @@
+{
+  "Identifier": "GHSA-qq97-vm5h-rrhg",
+  "PackageSlug": "go/github.com/docker/distribution",
+  "Title": "OCI Manifest Type Confusion Issue",
+  "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",
+  "Date": "2022-02-11",
+  "Pubdate": "2022-02-08",
+  "AffectedRange": "\u003cv2.8.0",
+  "FixedVersions": [
+    "v2.8.0"
+  ],
+  "AffectedVersions": "All versions before 2.8.0",
+  "NotImpacted": "All versions starting from 2.8.0",
+  "Solution": "Upgrade to version 2.8.0 or above.",
+  "Urls": [
+    "https://github.com/distribution/distribution/security/advisories/GHSA-qq97-vm5h-rrhg",
+    "https://github.com/opencontainers/image-spec/pull/411",
+    "https://github.com/distribution/distribution/commit/b59a6f827947f9e0e67df0cfb571046de4733586",
+    "https://github.com/advisories/GHSA-qq97-vm5h-rrhg"
+  ],
+  "CvssV2": "",
+  "CvssV3": "",
+  "UUID": "26cd05d1-2cb6-45b1-a990-09c37bb1c68d"
+}

--- a/glad/testdata/happy/go/github.com/docker/distribution/GMS-2022-20.yml
+++ b/glad/testdata/happy/go/github.com/docker/distribution/GMS-2022-20.yml
@@ -1,0 +1,33 @@
+---
+identifier: "GMS-2022-20"
+identifiers:
+- "GHSA-qq97-vm5h-rrhg"
+- "GMS-2022-20"
+package_slug: "go/github.com/docker/distribution"
+title: "OCI Manifest Type Confusion Issue"
+description: "### Impact\n\nSystems that rely on digest equivalence for image attestations
+  may be vulnerable to type confusion."
+date: "2022-02-11"
+pubdate: "2022-02-08"
+affected_range: "<v2.8.0"
+fixed_versions:
+- "v2.8.0"
+affected_versions: "All versions before 2.8.0"
+not_impacted: "All versions starting from 2.8.0"
+solution: "Upgrade to version 2.8.0 or above."
+urls:
+- "https://github.com/distribution/distribution/security/advisories/GHSA-qq97-vm5h-rrhg"
+- "https://github.com/opencontainers/image-spec/pull/411"
+- "https://github.com/distribution/distribution/commit/b59a6f827947f9e0e67df0cfb571046de4733586"
+- "https://github.com/advisories/GHSA-qq97-vm5h-rrhg"
+uuid: "26cd05d1-2cb6-45b1-a990-09c37bb1c68d"
+cwe_ids:
+- "CWE-1035"
+- "CWE-937"
+versions:
+- number: "v2.8.0"
+  commit:
+    tags:
+    - "v2.8.0"
+    sha: "6a39a64256119a41e3394ac1d814c8dd38195f76"
+    timestamp: "20220207154021"

--- a/glad/testdata/happy/go/github.com/docker/distribution/GMS-2022-20.yml
+++ b/glad/testdata/happy/go/github.com/docker/distribution/GMS-2022-20.yml
@@ -7,7 +7,7 @@ package_slug: "go/github.com/docker/distribution"
 title: "OCI Manifest Type Confusion Issue"
 description: "### Impact\n\nSystems that rely on digest equivalence for image attestations
   may be vulnerable to type confusion."
-date: "2022-02-11"
+date: "2022-04-19"
 pubdate: "2022-02-08"
 affected_range: "<v2.8.0"
 fixed_versions:

--- a/glad/types.go
+++ b/glad/types.go
@@ -2,6 +2,7 @@ package glad
 
 type advisory struct {
 	Identifier       string   `yaml:"identifier"`
+	Identifiers      []string `yaml:"identifiers" json:"identifiers,omitempty"`
 	PackageSlug      string   `yaml:"package_slug"`
 	Title            string   `yaml:"title"`
 	Description      string   `yaml:"description"`


### PR DESCRIPTION
GitLab advisory database contains GMS identifiers, and we should handle them.