### PR TITLE
fix(rocky): added 2 urls parse

### DIFF
--- a/rocky/types.go
+++ b/rocky/types.go
@@ -1,0 +1,59 @@
+package rocky
+
+// RepoMd has repomd data
+type RepoMd struct {
+	RepoList []Repo `xml:"data"`
+}
+
+// Repo has a repo data
+type Repo struct {
+	Type     string   `xml:"type,attr"`
+	Location Location `xml:"location"`
+}
+
+// Location has a location of repomd
+type Location struct {
+	Href string `xml:"href,attr"`
+}
+
+// UpdateInfo has a list
+type UpdateInfo struct {
+	RLSAList []RLSA `xml:"update"`
+}
+
+// RLSA has detailed data of RLSA
+type RLSA struct {
+	ID          string      `xml:"id" json:"id,omitempty"`
+	Title       string      `xml:"title" json:"title,omitempty"`
+	Issued      Date        `xml:"issued" json:"issued,omitempty"`
+	Updated     Date        `xml:"updated" json:"updated,omitempty"`
+	Severity    string      `xml:"severity" json:"severity,omitempty"`
+	Description string      `xml:"description" json:"description,omitempty"`
+	Packages    []Package   `xml:"pkglist>collection>package" json:"packages,omitempty"`
+	References  []Reference `xml:"references>reference" json:"references,omitempty"`
+	CveIDs      []string    `json:"cveids,omitempty"`
+}
+
+// Date has time information
+type Date struct {
+	Date string `xml:"date,attr" json:"date,omitempty"`
+}
+
+// Reference has reference information
+type Reference struct {
+	Href  string `xml:"href,attr" json:"href,omitempty"`
+	ID    string `xml:"id,attr" json:"id,omitempty"`
+	Title string `xml:"title,attr" json:"title,omitempty"`
+	Type  string `xml:"type,attr" json:"type,omitempty"`
+}
+
+// Package has affected package information
+type Package struct {
+	Name     string `xml:"name,attr" json:"name,omitempty"`
+	Epoch    string `xml:"epoch,attr" json:"epoch,omitempty"`
+	Version  string `xml:"version,attr" json:"version,omitempty"`
+	Release  string `xml:"release,attr" json:"release,omitempty"`
+	Arch     string `xml:"arch,attr" json:"arch,omitempty"`
+	Src      string `xml:"src,attr" json:"src,omitempty"`
+	Filename string `xml:"filename" json:"filename,omitempty"`
+}


### PR DESCRIPTION
## Description
Rocky database has been split into 2 urls:
- https://dl.rockylinux.org/vault/rocky
- https://download.rockylinux.org/pub/rocky

Added parsing of both links.