### PR TITLE
feat(ghsa): add Erlang/Elixir advisory

### DIFF
--- a/ghsa/ghsa.go
+++ b/ghsa/ghsa.go
@@ -29,7 +29,8 @@ var (
 	Pip        SecurityAdvisoryEcosystem = "PIP"
 	Rubygems   SecurityAdvisoryEcosystem = "RUBYGEMS"
 	Go         SecurityAdvisoryEcosystem = "GO"
-	Ecosystems                           = []SecurityAdvisoryEcosystem{Composer, Maven, Npm, Nuget, Pip, Rubygems, Go}
+	Erlang     SecurityAdvisoryEcosystem = "ERLANG"
+	Ecosystems                           = []SecurityAdvisoryEcosystem{Composer, Maven, Npm, Nuget, Pip, Rubygems, Go, Erlang}
 
 	wait = func(i int) time.Duration {
 		sleep := math.Pow(float64(i), 2) + float64(utils.RandInt()%10)


### PR DESCRIPTION
Erlang has been added to the GitHub Security Advisory.
https://github.blog/changelog/2022-06-27-github-advisory-database-now-includes-erlang-and-elixir-advisories/

At the time I checked, it is not reflected in the docs.
https://docs.github.com/en/graphql/reference/enums#securityadvisoryecosystem

However, it seems that `ERLANG` is added to the schema.
https://github.com/octokit/graphql-schema/blob/34d7f06ea7d0e35c43048c1e82e3c654be0220b7/schema.d.ts#L20727-L20728
