### PR TITLE
fix(oracle-oval): added release date.

### DIFF
--- a/oracle/oval/testdata/golden/ELSA-2007-0057.json
+++ b/oracle/oval/testdata/golden/ELSA-2007-0057.json
@@ -145,5 +145,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2007-0494.html",
       "ID": "CVE-2007-0494"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2007-06-26"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2008-0110.json
+++ b/oracle/oval/testdata/golden/ELSA-2008-0110.json
@@ -121,5 +121,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2008-0658.html",
       "ID": "CVE-2008-0658"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2008-02-21"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2009-1203.json
+++ b/oracle/oval/testdata/golden/ELSA-2009-1203.json
@@ -111,5 +111,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2009-2411.html",
       "ID": "CVE-2009-2411"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2009-08-10"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2010-0809.json
+++ b/oracle/oval/testdata/golden/ELSA-2010-0809.json
@@ -63,5 +63,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2010-3765.html",
       "ID": "CVE-2010-3765"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2010-10-28"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2011-1268.json
+++ b/oracle/oval/testdata/golden/ELSA-2011-1268.json
@@ -123,5 +123,8 @@
     "Criterions": null
   },
   "Severity": "IMPORTANT",
-  "Cves": null
+  "Cves": null,
+  "Issued": {
+    "Date": "2011-09-07"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2012-1261.json
+++ b/oracle/oval/testdata/golden/ELSA-2012-1261.json
@@ -99,5 +99,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2012-3524.html",
       "ID": "CVE-2012-3524"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2012-09-13"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2013-1732.json
+++ b/oracle/oval/testdata/golden/ELSA-2013-1732.json
@@ -63,5 +63,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2013-1813.html",
       "ID": "CVE-2013-1813"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2013-11-25"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2014-2010.json
+++ b/oracle/oval/testdata/golden/ELSA-2014-2010.json
@@ -183,5 +183,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2014-9322.html",
       "ID": "CVE-2014-9322"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2014-12-18"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2015-2561.json
+++ b/oracle/oval/testdata/golden/ELSA-2015-2561.json
@@ -231,5 +231,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2015-7545.html",
       "ID": "CVE-2015-7545"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2015-12-08"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2016-3646.json
+++ b/oracle/oval/testdata/golden/ELSA-2016-3646.json
@@ -266,5 +266,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2016-6136.html",
       "ID": "CVE-2016-6136"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2016-11-20"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2017-3516.json
+++ b/oracle/oval/testdata/golden/ELSA-2017-3516.json
@@ -246,5 +246,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2015-1420.html",
       "ID": "CVE-2015-1420"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2017-02-09"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2018-1196-1.json
+++ b/oracle/oval/testdata/golden/ELSA-2018-1196-1.json
@@ -255,5 +255,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2017-5715.html",
       "ID": "CVE-2017-5715"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2018-08-03"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2018-3410.json
+++ b/oracle/oval/testdata/golden/ELSA-2018-3410.json
@@ -147,5 +147,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2018-14665.html",
       "ID": "CVE-2018-14665"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2018-11-07"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2019-4820.json
+++ b/oracle/oval/testdata/golden/ELSA-2019-4820.json
@@ -231,5 +231,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2019-14835.html",
       "ID": "CVE-2019-14835"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2019-10-11"
+  }
 }

--- a/oracle/oval/testdata/golden/ELSA-2019-4821.json
+++ b/oracle/oval/testdata/golden/ELSA-2019-4821.json
@@ -63,5 +63,8 @@
       "Href": "http://linux.oracle.com/cve/CVE-2019-14287.html",
       "ID": "CVE-2019-14287"
     }
-  ]
+  ],
+  "Issued": {
+    "Date": "2019-10-15"
+  }
 }

--- a/oracle/oval/types.go
+++ b/oracle/oval/types.go
@@ -12,6 +12,7 @@ type Definition struct {
 	Criteria    Criteria    `xml:"criteria"`
 	Severity    string      `xml:"metadata>advisory>severity"`
 	Cves        []Cve       `xml:"metadata>advisory>cve"`
+	Issued      Issued      `xml:"metadata>advisory>issued" json:",omitempty"`
 }
 
 type Reference struct {
@@ -34,4 +35,8 @@ type Criteria struct {
 
 type Criterion struct {
 	Comment string `xml:"comment,attr"`
+}
+
+type Issued struct {
+	Date string `xml:"date,attr" json:",omitempty"`
 }

--- a/oracle/oval/types_test.go
+++ b/oracle/oval/types_test.go
@@ -167,6 +167,9 @@ func TestRedhatCVEJSON_UnmarshalJSON(t *testing.T) {
 								ID:     "CVE-2007-0494",
 							},
 						},
+						Issued: oval.Issued{
+							Date: "2007-06-26",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Oracle-oval release date not capturing. 

Added Issued in the types. this will pull the release date.

![oracle](https://user-images.githubusercontent.com/10487510/203070597-2146fb14-615f-4b37-af1e-87e95e6948ce.png)
