### PR TITLE
fix(glad): select CVE-ID before GHSA-ID

### DIFF
--- a/glad/glad.go
+++ b/glad/glad.go
@@ -177,8 +177,15 @@ func updateIdentifiers(basicIdentifier string, basicIdentifiers []string) string
 	// https://gitlab.com/gitlab-org/advisories-community/-/blob/74a18a7968c2bdd2dd901f6c98f06cb1d9684476/maven/org.picketlink/picketlink-common/cvE-2014-3530.yml
 	updated := strings.ToUpper(basicIdentifier)
 
-	// If an advisory doesn't have CVE-ID but there is GHSA-ID, we use GHSA-ID
+	// If a `basicIdentifier` is not CVE-ID, then try to find CVE-ID or GHSA-ID in `basicIdentifiers`
 	if !strings.HasPrefix(updated, "CVE") {
+		// Try to find `CVE-ID`
+		for i := range basicIdentifiers {
+			if ident := strings.ToUpper(basicIdentifiers[i]); strings.HasPrefix(ident, "CVE") {
+				return ident
+			}
+		}
+		// If `CVE-ID` didn't find, then try to find `GHSA-ID`
 		for i := range basicIdentifiers {
 			if ident := strings.ToUpper(basicIdentifiers[i]); strings.HasPrefix(ident, "GHSA") {
 				// return no uppercase string because GHSA id contains small letters (eg GHSA-qq97-vm5h-rrhg)

--- a/glad/glad.go
+++ b/glad/glad.go
@@ -185,7 +185,7 @@ func updateIdentifiers(basicIdentifier string, basicIdentifiers []string) string
 				return ident
 			}
 		}
-		// If `CVE-ID` didn't find, then try to find `GHSA-ID`
+		// If `CVE-ID` is not found, then try to find `GHSA-ID`
 		for i := range basicIdentifiers {
 			if ident := strings.ToUpper(basicIdentifiers[i]); strings.HasPrefix(ident, "GHSA") {
 				// return no uppercase string because GHSA id contains small letters (eg GHSA-qq97-vm5h-rrhg)

--- a/glad/glad_test.go
+++ b/glad/glad_test.go
@@ -28,7 +28,7 @@ func TestUpdater_WalkDir(t *testing.T) {
 			name:          "happy path",
 			rootDir:       "testdata/happy",
 			goldenDir:     "testdata/golden/happy",
-			wantFileCount: 5,
+			wantFileCount: 6,
 		},
 		{
 			name:          "happy path, skip slug update for maven",

--- a/glad/testdata/golden/happy/glad/maven/org.springframework.boot/spring-boot-starter-web/CVE-2022-22965.json
+++ b/glad/testdata/golden/happy/glad/maven/org.springframework.boot/spring-boot-starter-web/CVE-2022-22965.json
@@ -1,0 +1,30 @@
+{
+  "Identifier": "CVE-2022-22965",
+  "PackageSlug": "maven/org.springframework.boot/spring-boot-starter-web",
+  "Title": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+  "Description": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') in org.springframework.boot:spring-boot-starter-web.",
+  "Date": "2022-03-31",
+  "Pubdate": "2022-03-31",
+  "AffectedRange": "(,2.5.12),[2.6.0,2.6.6)",
+  "FixedVersions": [
+    "2.5.12",
+    "2.6.6"
+  ],
+  "AffectedVersions": "All versions before 2.5.12, all versions starting from 2.6.0 before 2.6.6",
+  "NotImpacted": "All versions starting from 2.5.12 before 2.6.0, all versions starting from 2.6.6",
+  "Solution": "Upgrade to versions 2.5.12, 2.6.6 or above.",
+  "Urls": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2022-22965",
+    "https://github.com/spring-projects/spring-framework/commit/002546b3e4b8d791ea6acccb81eb3168f51abb15",
+    "https://github.com/spring-projects/spring-boot/releases/tag/v2.5.12",
+    "https://github.com/spring-projects/spring-boot/releases/tag/v2.6.6",
+    "https://github.com/spring-projects/spring-framework/releases/tag/v5.2.20.RELEASE",
+    "https://github.com/spring-projects/spring-framework/releases/tag/v5.3.18",
+    "https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement",
+    "https://tanzu.vmware.com/security/cve-2022-22965",
+    "https://github.com/advisories/GHSA-36p3-wjmg-h94x"
+  ],
+  "CvssV2": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+  "CvssV3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+  "UUID": "4707032c-92a4-4447-99db-82dd610d4037"
+}

--- a/glad/testdata/happy/maven/org.springframework.boot/spring-boot-starter-web/GMS-2022-560.yml
+++ b/glad/testdata/happy/maven/org.springframework.boot/spring-boot-starter-web/GMS-2022-560.yml
@@ -1,0 +1,40 @@
+---
+identifier: "GMS-2022-560"
+identifiers:
+  - "GHSA-36p3-wjmg-h94x"
+  - "GMS-2022-560"
+  - "CVE-2022-22965"
+package_slug: "maven/org.springframework.boot/spring-boot-starter-web"
+title: "Improper Neutralization of Special Elements used in an OS Command ('OS Command
+  Injection')"
+description: "Improper Neutralization of Special Elements used in an OS Command ('OS
+  Command Injection') in org.springframework.boot:spring-boot-starter-web."
+date: "2022-03-31"
+pubdate: "2022-03-31"
+affected_range: "(,2.5.12),[2.6.0,2.6.6)"
+fixed_versions:
+  - "2.5.12"
+  - "2.6.6"
+affected_versions: "All versions before 2.5.12, all versions starting from 2.6.0 before
+  2.6.6"
+not_impacted: "All versions starting from 2.5.12 before 2.6.0, all versions starting
+  from 2.6.6"
+solution: "Upgrade to versions 2.5.12, 2.6.6 or above."
+urls:
+  - "https://nvd.nist.gov/vuln/detail/CVE-2022-22965"
+  - "https://github.com/spring-projects/spring-framework/commit/002546b3e4b8d791ea6acccb81eb3168f51abb15"
+  - "https://github.com/spring-projects/spring-boot/releases/tag/v2.5.12"
+  - "https://github.com/spring-projects/spring-boot/releases/tag/v2.6.6"
+  - "https://github.com/spring-projects/spring-framework/releases/tag/v5.2.20.RELEASE"
+  - "https://github.com/spring-projects/spring-framework/releases/tag/v5.3.18"
+  - "https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement"
+  - "https://tanzu.vmware.com/security/cve-2022-22965"
+  - "https://github.com/advisories/GHSA-36p3-wjmg-h94x"
+cvss_v2: "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+cvss_v3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+uuid: "4707032c-92a4-4447-99db-82dd610d4037"
+cwe_ids:
+  - "CWE-1035"
+  - "CWE-78"
+  - "CWE-937"
+


### PR DESCRIPTION
## Description
GitLab can use `GSM-xxx`  as `identifier`.
First we need  find `CVE-ID`. If `CVE-ID` is not found, then try to find `GHSA-ID`.
e.g. - https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/master/maven/org.springframework.boot/spring-boot-starter-web/GMS-2022-560.yml

## Related Issues
- https://github.com/aquasecurity/trivy/issues/4176