### PR TITLE
ci: squash `vuln-list` using git-filter-repo

### DIFF
--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -26,7 +26,6 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
         git push -f https://${GITHUB_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
         cd .. && rm -r -f vuln-list-all
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -12,16 +12,17 @@ jobs:
       GITHUB_OWNER: ${{ github.repository_owner }}
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
-    - name: Setup github user email and name
-      run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "GitHub Action"
-
     - name: clone the whole repo for backup
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
         path: vuln-list-all
+        token: ${{ secrets.ACCESS_TOKEN }}
+
+    - name: Setup github user email and name
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
 
     - name: back up vuln-list
       run: |

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -27,7 +27,7 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
+        git remote set-url origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
         git push -f
         cd .. && rm -r -f vuln-list-all
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         cd vuln-list-all
         git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
-        git push -f
+        git push https://${GITHUB_TOKEN}@github.com/GITHUB_OWNER/vuln-list-backup.git main
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -12,25 +12,10 @@ jobs:
       GITHUB_OWNER: ${{ github.repository_owner }}
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
-    - name: clone the whole repo for backup
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ github.repository_owner }}/vuln-list
-        fetch-depth: 0
-        path: vuln-list-all
-        token: ${{ secrets.ACCESS_TOKEN }}
-
     - name: Setup github user email and name
       run: |
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
-
-    - name: back up vuln-list
-      run: |
-        cd vuln-list-all
-        git remote set-url origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
-        git push -f
-        cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo
       uses: actions/checkout@v3

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -10,14 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_OWNER: ${{ github.repository_owner }}
-      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
     - name: Setup github user email and name
       run: |
-        git config --global user.email "work@afdesk.com"
-        git config --global user.name "afdesk"
-#        git config --global user.email "action@github.com"
-#        git config --global user.name "GitHub Action"
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
 
     - name: clone the whole repo for backup
       uses: actions/checkout@v3
@@ -28,7 +26,7 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git push -f https://${GITHUB_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
+        git push -f https://${PERSONAL_ACCESS_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -27,7 +27,7 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git remote set-url origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
+        git remote add origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
         git push -f
         cd .. && rm -r -f vuln-list-all
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
-      path: vuln-list-all
+        path: vuln-list-all
 
     - name: back up vuln-list
       run: |
@@ -31,8 +31,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
-      path: vuln-list
-      fetch-depth: 100
+        path: vuln-list
+        fetch-depth: 100
 
     - name: squash and push
       run: |

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -12,6 +12,11 @@ jobs:
       GITHUB_OWNER: ${{ github.repository_owner }}
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install filter-repo
+
     - name: Setup github user email and name
       run: |
         git config --global user.email "action@github.com"
@@ -23,11 +28,15 @@ jobs:
         repository: ${{ github.repository_owner }}/vuln-list
         token: ${{ secrets.ACCESS_TOKEN }}
         path: vuln-list
-        fetch-depth: 100
+        fetch-depth: 20
 
     - name: squash and push
       run: |
         cd vuln-list
         git replace -f --graft $(git rev-list --max-parents=0 HEAD)
-        git filter-branch -- --all
-        git push -f
+        git filter-repo --force
+        git remote add origin https://github.com/afdesk/vuln-list.git
+        git push --force --set-upstream https://${GITHUB_TOKEN}@github.com/afdesk/vuln-list.git main
+#        git push --set-upstream origin main --force
+#        git filter-branch -- --all
+#        git push -f

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -19,7 +19,7 @@ jobs:
     - name: clone the whole repo for backup
       uses: actions/checkout@v3
       with:
-      repository: ${{ github.repository_owner }}/vuln-list
+        repository: ${{ github.repository_owner }}/vuln-list
       path: vuln-list-all
 
     - name: back up vuln-list
@@ -30,7 +30,7 @@ jobs:
     - name: clone a shallow repo
       uses: actions/checkout@v3
       with:
-      repository: ${{ github.repository_owner }}/vuln-list
+        repository: ${{ github.repository_owner }}/vuln-list
       path: vuln-list
       fetch-depth: 100
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_OWNER: ${{ github.repository_owner }}
-      PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
     - name: Setup github user email and name
       run: |
@@ -26,7 +26,8 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git push -f https://${PERSONAL_ACCESS_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
+        git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
+        git push -f
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -37,6 +37,3 @@ jobs:
         git filter-repo --force
         git remote add origin https://github.com/afdesk/vuln-list.git
         git push --force --set-upstream https://${GITHUB_TOKEN}@github.com/afdesk/vuln-list.git main
-#        git push --set-upstream origin main --force
-#        git filter-branch -- --all
-#        git push -f

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         cd vuln-list-all
         git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
-        git push https://${GITHUB_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
+        git push -f
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install filter-repo
+        sudo apt-get -y install git-filter-repo
 
     - name: Setup github user email and name
       run: |

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_OWNER: ${{ github.repository_owner }}
+      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
     - name: Setup github user email and name
       run: |
@@ -26,7 +27,7 @@ jobs:
       run: |
         cd vuln-list-all
         git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
-        git push -f
+        git push -f https://${GITHUB_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -28,7 +28,7 @@ jobs:
         repository: ${{ github.repository_owner }}/vuln-list
         token: ${{ secrets.ACCESS_TOKEN }}
         path: vuln-list
-        fetch-depth: 20
+        fetch-depth: 100
 
     - name: squash and push
       run: |

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -24,8 +24,10 @@ jobs:
 
     - name: back up vuln-list
       run: |
+        cd vuln-list-all
         git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
         git push -f
+        cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo
       uses: actions/checkout@v3
@@ -36,6 +38,7 @@ jobs:
 
     - name: squash and push
       run: |
+        cd vuln-list
         git replace -f --graft $(git rev-list --max-parents=0 HEAD)
         git filter-branch -- --all
         git push -f

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
+        fetch-depth: 0
         path: vuln-list-all
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -27,7 +28,7 @@ jobs:
     - name: back up vuln-list
       run: |
         cd vuln-list-all
-        git remote add origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
+        git remote set-url origin https://github.com/$GITHUB_OWNER/vuln-list-backup.git
         git push -f
         cd .. && rm -r -f vuln-list-all
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         cd vuln-list-all
         git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
-        git push https://${GITHUB_TOKEN}@github.com/GITHUB_OWNER/vuln-list-backup.git main
+        git push https://${GITHUB_TOKEN}@github.com/$GITHUB_OWNER/vuln-list-backup.git main
         cd .. && rm -r -f vuln-list-all
 
     - name: clone a shallow repo

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -8,32 +8,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_OWNER: ${{ github.repository_owner }}
-      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
     - name: Install dependencies
       run: |
         sudo apt-get -y update
         sudo apt-get -y install git-filter-repo
 
-    - name: Setup github user email and name
+    - name: Setup GitHub user email and name
       run: |
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
 
-    - name: clone a shallow repo
+    - name: Clone a shallow repo
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
         token: ${{ secrets.ACCESS_TOKEN }}
         path: vuln-list
-        fetch-depth: 100
+        fetch-depth: 2000
 
-    - name: squash and push
+    - name: Squash and push
       run: |
         cd vuln-list
         git replace -f --graft $(git rev-list --max-parents=0 HEAD)
         git filter-repo --force
-        git remote add origin https://github.com/afdesk/vuln-list.git
-        git push --force --set-upstream https://${GITHUB_TOKEN}@github.com/afdesk/vuln-list.git main
+        git push --force --set-upstream https://${{ secrets.ACCESS_TOKEN }}@github.com/${{ github.repository_owner }}/vuln-list.git main

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/vuln-list
+        token: ${{ secrets.ACCESS_TOKEN }}
         path: vuln-list
         fetch-depth: 100
 

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
     - name: Setup github user email and name
       run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "GitHub Action"
+        git config --global user.email "work@afdesk.com"
+        git config --global user.name "afdesk"
+#        git config --global user.email "action@github.com"
+#        git config --global user.name "GitHub Action"
 
     - name: clone the whole repo for backup
       uses: actions/checkout@v3

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -1,0 +1,41 @@
+name: Squash vuln-list repo
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OWNER: ${{ github.repository_owner }}
+    steps:
+    - name: Setup github user email and name
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
+
+    - name: clone the whole repo for backup
+      uses: actions/checkout@v3
+      with:
+      repository: ${{ github.repository_owner }}/vuln-list
+      path: vuln-list-all
+
+    - name: back up vuln-list
+      run: |
+        git remote set-url origin git@github.com:$GITHUB_OWNER/vuln-list-backup.git
+        git push -f
+
+    - name: clone a shallow repo
+      uses: actions/checkout@v3
+      with:
+      repository: ${{ github.repository_owner }}/vuln-list
+      path: vuln-list
+      fetch-depth: 100
+
+    - name: squash and push
+      run: |
+        git replace -f --graft $(git rev-list --max-parents=0 HEAD)
+        git filter-branch -- --all
+        git push -f


### PR DESCRIPTION
Now `vuln-list` is a large repository that contains about 20'000 commits and 117'000'000 objects.
the total size is about 24Gb.
Github has a limit for repositories - 5Gb.

so we have to squash vuln-list - clone the shallow repository (the last 100 commits), squash and push.
