### PR TITLE
fix(debian): remove line

### DIFF
--- a/debian/tracker/annotation.go
+++ b/debian/tracker/annotation.go
@@ -37,13 +37,23 @@ var (
 	bugNoRegexp    = regexp.MustCompile(`bug #(?P<bugno>\d+)`)
 
 	// ref. https://salsa.debian.org/security-tracker-team/security-tracker/-/blob/50ca55fb66ec7592f9bc1053a11dbf0bd50ee425/lib/python/sectracker/parsers.py#L140-141
-	pseudoFreeText = []string{"no-dsa", "not-affected", "end-of-life", "ignored", "postponed"}
-	pseudoStruct   = []string{"unfixed", "removed", "itp", "undetermined"}
+	pseudoFreeText = []string{
+		"no-dsa",
+		"not-affected",
+		"end-of-life",
+		"ignored",
+		"postponed",
+	}
+	pseudoStruct = []string{
+		"unfixed",
+		"removed",
+		"itp",
+		"undetermined",
+	}
 )
 
 type Annotation struct {
 	Original    string   `json:",omitempty"`
-	Line        int      `json:",omitempty"`
 	Type        string   `json:",omitempty"`
 	Release     string   `json:",omitempty"`
 	Package     string   `json:",omitempty"`
@@ -78,7 +88,7 @@ func newAnnotationDispatcher() annotationDispatcher {
 	}
 }
 
-func (d annotationDispatcher) parseAnnotation(line string, lineno int) *Annotation {
+func (d annotationDispatcher) parseAnnotation(line string) *Annotation {
 	var once sync.Once
 	var ann *Annotation
 
@@ -88,7 +98,6 @@ func (d annotationDispatcher) parseAnnotation(line string, lineno int) *Annotati
 			once.Do(func() {
 				ann = &Annotation{
 					Original: strings.TrimSpace(line),
-					Line:     lineno,
 				}
 			})
 			p.Apply(match, ann)

--- a/debian/tracker/debian.go
+++ b/debian/tracker/debian.go
@@ -186,13 +186,11 @@ func (c Client) parseList(parser listParser, filename string) ([]Bug, error) {
 		bugs   []Bug
 		anns   []*Annotation
 		header *Header
-		lineno int
 	)
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		line := s.Text()
-		lineno += 1
 
 		switch {
 		case line == "":
@@ -203,7 +201,7 @@ func (c Client) parseList(parser listParser, filename string) ([]Bug, error) {
 				continue
 			}
 
-			ann := c.annDispatcher.parseAnnotation(line, lineno)
+			ann := c.annDispatcher.parseAnnotation(line)
 			if ann != nil {
 				anns = append(anns, ann)
 			}
@@ -223,7 +221,6 @@ func (c Client) parseList(parser listParser, filename string) ([]Bug, error) {
 				log.Printf("malformed header: %s", line)
 				continue
 			}
-			header.Line = lineno
 		}
 	}
 

--- a/debian/tracker/debian_test.go
+++ b/debian/tracker/debian_test.go
@@ -37,14 +37,12 @@ func TestClient_Update(t *testing.T) {
 				filepath.Join("DLA", "DLA-2711-1.json"): {
 					Header: &tracker.Header{
 						Original:    "[19 Jul 2021] DLA-2711-1 thunderbird - security update",
-						Line:        1,
 						ID:          "DLA-2711-1",
 						Description: "thunderbird - security update",
 					},
 					Annotations: []*tracker.Annotation{
 						{
 							Original: "{CVE-2021-29969 CVE-2021-29970 CVE-2021-29976 CVE-2021-30547}",
-							Line:     2,
 							Type:     "xref",
 							Bugs: []string{
 								"CVE-2021-29969",
@@ -55,7 +53,6 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original: "[stretch] - thunderbird 1:78.12.0-1~deb9u1",
-							Line:     3,
 							Type:     "package",
 							Release:  "stretch",
 							Package:  "thunderbird",
@@ -67,14 +64,12 @@ func TestClient_Update(t *testing.T) {
 				filepath.Join("DSA", "DSA-4480-1.json"): {
 					Header: &tracker.Header{
 						Original:    "[11 Jul 2019] DSA-4480-1 redis - security update",
-						Line:        1,
 						ID:          "DSA-4480-1",
 						Description: "redis - security update",
 					},
 					Annotations: []*tracker.Annotation{
 						{
 							Original: "{CVE-2019-10192 CVE-2019-10193}",
-							Line:     2,
 							Type:     "xref",
 							Bugs: []string{
 								"CVE-2019-10192",
@@ -83,7 +78,6 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original: "[stretch] - redis 3:3.2.6-3+deb9u3",
-							Line:     3,
 							Type:     "package",
 							Release:  "stretch",
 							Package:  "redis",
@@ -92,7 +86,6 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original: "[buster] - redis 5:5.0.3-4+deb10u1",
-							Line:     4,
 							Type:     "package",
 							Release:  "buster",
 							Package:  "redis",
@@ -104,14 +97,12 @@ func TestClient_Update(t *testing.T) {
 				filepath.Join("CVE", "2021", "CVE-2021-36373.json"): {
 					Header: &tracker.Header{
 						Original:    "CVE-2021-36373 (When reading a specially crafted TAR archive an Apache Ant build can b ...)",
-						Line:        5,
 						ID:          "CVE-2021-36373",
 						Description: "(When reading a specially crafted TAR archive an Apache Ant build can b ...)",
 					},
 					Annotations: []*tracker.Annotation{
 						{
 							Original: "- ant <unfixed> (unimportant)",
-							Line:     6,
 							Type:     "package",
 							Kind:     "unfixed",
 							Package:  "ant",
@@ -119,13 +110,11 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original:    "NOTE: https://www.openwall.com/lists/oss-security/2021/07/13/5",
-							Line:        7,
 							Type:        "NOTE",
 							Description: "https://www.openwall.com/lists/oss-security/2021/07/13/5",
 						},
 						{
 							Original:    "NOTE: Crash in CLI tool, no security impact",
-							Line:        8,
 							Type:        "NOTE",
 							Description: "Crash in CLI tool, no security impact",
 						},
@@ -134,14 +123,12 @@ func TestClient_Update(t *testing.T) {
 				filepath.Join("CVE", "2021", "CVE-2021-36367.json"): {
 					Header: &tracker.Header{
 						Original:    "CVE-2021-36367 (PuTTY through 0.75 proceeds with establishing an SSH session even if i ...)",
-						Line:        10,
 						ID:          "CVE-2021-36367",
 						Description: "(PuTTY through 0.75 proceeds with establishing an SSH session even if i ...)",
 					},
 					Annotations: []*tracker.Annotation{
 						{
 							Original: "- putty 0.75-3 (low; bug #990901)",
-							Line:     11,
 							Type:     "package",
 							Version:  "0.75-3",
 							Kind:     "fixed",
@@ -151,7 +138,6 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original:    "[bullseye] - putty <no-dsa> (Minor issue)",
-							Line:        12,
 							Type:        "package",
 							Release:     "bullseye",
 							Kind:        "no-dsa",
@@ -160,7 +146,6 @@ func TestClient_Update(t *testing.T) {
 						},
 						{
 							Original:    "[buster] - putty <no-dsa> (Minor issue)",
-							Line:        13,
 							Type:        "package",
 							Release:     "buster",
 							Kind:        "no-dsa",

--- a/debian/tracker/list.go
+++ b/debian/tracker/list.go
@@ -18,7 +18,6 @@ var (
 
 type Header struct {
 	Original    string `json:",omitempty"`
-	Line        int    `json:",omitempty"`
 	ID          string `json:",omitempty"`
 	Description string `json:",omitempty"`
 }


### PR DESCRIPTION
## Description
Line numbers are frequently updated, and it increases the repository size dramatically.
https://github.com/aquasecurity/vuln-list-debian/commit/2b34d21590746aa7314fde530fe70478151a4156

Although vuln-list-debian should keep the original content as much ass possible, the repository size is critical. This PR drops line numbers as it is not used in trivy-db.