### PR TITLE
refactor(ghsa): use ghsa repository instead of API to get advisories

### DIFF
--- a/ghsa/ghsa_test.go
+++ b/ghsa/ghsa_test.go
@@ -1,16 +1,12 @@
 package ghsa
 
 import (
-	"context"
-	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
-	githubql "github.com/shurcooL/githubv4"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,458 +14,55 @@ import (
 
 var update = flag.Bool("update", false, "update golden files")
 
-type MockClient struct {
-	Response   map[githubql.String]GetVulnerabilitiesQuery
-	Error      error
-	ErrorCount int
-}
-
-func (mc MockClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
-	if mc.Error != nil {
-		return mc.Error
-	}
-
-	cursor := variables["cursor"].(*githubql.String)
-	if cursor == (*githubql.String)(nil) {
-		q.(*GetVulnerabilitiesQuery).SecurityVulnerabilities = mc.Response[githubql.String("")].SecurityVulnerabilities
-		return nil
-	}
-
-	q.(*GetVulnerabilitiesQuery).SecurityVulnerabilities = mc.Response[*cursor].SecurityVulnerabilities
-	return nil
-}
-
-func TestConfig_Update(t *testing.T) {
+func TestUpdater_WalkDir(t *testing.T) {
 	testCases := []struct {
-		name             string
-		appFs            afero.Fs
-		inputEcosystem   SecurityAdvisoryEcosystem
-		goldenFiles      map[string]string
-		inputResponse    map[githubql.String]GetVulnerabilitiesQuery
-		expectedErrorMsg string
+		name          string
+		appFs         afero.Fs
+		rootDir       string
+		goldenDir     string
+		wantFileCount int
+		wantErr       string
 	}{
 		{
-			name:           "positive test",
-			appFs:          afero.NewMemMapFs(),
-			inputEcosystem: Composer,
-			goldenFiles: map[string]string{
-				"/tmp/ghsa/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json": "testdata/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json",
-			},
-			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
-				githubql.String(""): {
-					SecurityVulnerabilities: SecurityVulnerabilities{
-						Nodes: []GithubSecurityAdvisory{
-							{
-								Severity:  "LOW",
-								UpdatedAt: "2020-01-24T21:15:59Z",
-								Package: Package{
-									Ecosystem: "COMPOSER",
-									Name:      "simplesamlphp/simplesamlphp",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1883,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJyM3YtcTl4My03ZzQ2",
-									GhsaId:     "GHSA-2r3v-q9x3-7g46",
-									References: []Reference{
-										{
-											Url: "https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-2r3v-q9x3-7g46",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2r3v-q9x3-7g46",
-										},
-									},
-									Description: "### Background\nSeveral scripts part of SimpleSAMLphp display a web page with links obtained from the request parameters. This allows us to enhance usability, as the users are presented with links they can follow after completing a certain action, like logging out.\n\n### Description\nThe following scripts were not checking the URLs obtained via the HTTP request before displaying them as the target of links that the user may click on:\n\n- `www/logout.php`\n- `modules/core/www/no_cookie.php`\n\nThe issue allowed attackers to display links targeting a malicious website inside a trusted site running SimpleSAMLphp, due to the lack of security checks involving the `link_href` and `retryURL` HTTP parameters, respectively. The issue was resolved by including a verification of the URLs received in the request against a white list of websites specified in the `trusted.url.domains` configuration option.\n\n### Affected versions\nAll SimpleSAMLphp versions prior to 1.14.4.\n\n### Impact\nA remote attacker could craft a link pointing to a trusted website running SimpleSAMLphp, including a parameter pointing to a malicious website, and try to fool the victim into visiting that website by clicking on a link in the page presented by SimpleSAMLphp.\n\n### Resolution\nUpgrade to the latest version.\n\n### Credit\nThis security issue was discovered and reported by John Page (hyp3rlinx).",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2020-01-24T21:27:16Z",
-									Severity:    "LOW",
-									Summary:     "Low severity vulnerability that affects simplesamlphp/simplesamlphp",
-									UpdatedAt:   "2020-01-24T21:27:17Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        3.7,
-										VectorString: "3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "1.14.4",
-								},
-								VulnerableVersionRange: "\u003c 1.14.4",
-							},
-						},
-						PageInfo: PageInfo{
-							EndCursor:   githubql.String(""),
-							HasNextPage: false,
-						},
-					},
-				},
-			},
+			name:          "happy path",
+			rootDir:       "testdata/happy",
+			goldenDir:     "testdata/golden/happy",
+			wantFileCount: 6,
 		},
 		{
-			name:           "positive test with one nil node",
-			appFs:          afero.NewMemMapFs(),
-			inputEcosystem: Composer,
-			goldenFiles: map[string]string{
-				"/tmp/ghsa/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json": "testdata/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json",
-			},
-			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
-				githubql.String(""): {
-					SecurityVulnerabilities: SecurityVulnerabilities{
-						Nodes: []GithubSecurityAdvisory{
-							{
-								Severity:  "LOW",
-								UpdatedAt: "2020-01-24T21:15:59Z",
-								Package: Package{
-									Ecosystem: "COMPOSER",
-									Name:      "simplesamlphp/simplesamlphp",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1883,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJyM3YtcTl4My03ZzQ2",
-									GhsaId:     "GHSA-2r3v-q9x3-7g46",
-									References: []Reference{
-										{
-											Url: "https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-2r3v-q9x3-7g46",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2r3v-q9x3-7g46",
-										},
-									},
-									Description: "### Background\nSeveral scripts part of SimpleSAMLphp display a web page with links obtained from the request parameters. This allows us to enhance usability, as the users are presented with links they can follow after completing a certain action, like logging out.\n\n### Description\nThe following scripts were not checking the URLs obtained via the HTTP request before displaying them as the target of links that the user may click on:\n\n- `www/logout.php`\n- `modules/core/www/no_cookie.php`\n\nThe issue allowed attackers to display links targeting a malicious website inside a trusted site running SimpleSAMLphp, due to the lack of security checks involving the `link_href` and `retryURL` HTTP parameters, respectively. The issue was resolved by including a verification of the URLs received in the request against a white list of websites specified in the `trusted.url.domains` configuration option.\n\n### Affected versions\nAll SimpleSAMLphp versions prior to 1.14.4.\n\n### Impact\nA remote attacker could craft a link pointing to a trusted website running SimpleSAMLphp, including a parameter pointing to a malicious website, and try to fool the victim into visiting that website by clicking on a link in the page presented by SimpleSAMLphp.\n\n### Resolution\nUpgrade to the latest version.\n\n### Credit\nThis security issue was discovered and reported by John Page (hyp3rlinx).",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2020-01-24T21:27:16Z",
-									Severity:    "LOW",
-									Summary:     "Low severity vulnerability that affects simplesamlphp/simplesamlphp",
-									UpdatedAt:   "2020-01-24T21:27:17Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        3.7,
-										VectorString: "3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "1.14.4",
-								},
-								VulnerableVersionRange: "\u003c 1.14.4",
-							},
-							{}, // nil node
-						},
-						PageInfo: PageInfo{
-							EndCursor:   githubql.String(""),
-							HasNextPage: false,
-						},
-					},
-				},
-			},
+			name:          "happy path, skip slug update for maven",
+			rootDir:       "testdata/skip-slug-update",
+			goldenDir:     "testdata/golden/skip-slug-update",
+			wantFileCount: 2,
 		},
 		{
-			name:           "positive test multi nodes",
-			appFs:          afero.NewMemMapFs(),
-			inputEcosystem: Maven,
-			goldenFiles: map[string]string{
-				"/tmp/ghsa/maven/org.apache.solr/solr-core/GHSA-2289-pqfq-6wx7.json":   "testdata/maven/org.apache.solr/solr-core/GHSA-2289-pqfq-6wx7.json",
-				"/tmp/ghsa/maven/org.apache.qpid/qpid-broker/GHSA-269m-695x-j34p.json": "testdata/maven/org.apache.qpid/qpid-broker/GHSA-269m-695x-j34p.json",
-				"/tmp/ghsa/maven/org.apache.hive/hive/GHSA-2g9q-chq2-w8qw.json":        "testdata/maven/org.apache.hive/hive/GHSA-2g9q-chq2-w8qw.json",
-			},
-			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
-				githubql.String(""): {
-					SecurityVulnerabilities: SecurityVulnerabilities{
-						Nodes: []GithubSecurityAdvisory{
-							{
-								Severity:  "HIGH",
-								UpdatedAt: "2020-01-28T22:25:34Z",
-								Package: Package{
-									Ecosystem: "MAVEN",
-									Name:      "org.apache.solr:solr-core",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1892,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTIyODktcHFmcS02d3g3",
-									GhsaId:     "GHSA-2289-pqfq-6wx7",
-									References: []Reference{
-										{
-											Url: "https://nvd.nist.gov/vuln/detail/CVE-2019-12409",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2289-pqfq-6wx7",
-										},
-										{
-											Type:  "CVE",
-											Value: "CVE-2019-12409",
-										},
-									},
-									Description: "The 8.1.1 and 8.2.0 releases of Apache Solr contain an insecure setting for the ENABLE_REMOTE_JMX_OPTS configuration option in the default solr.in.sh configuration file shipping with Solr. If you use the default solr.in.sh file from the affected releases, then JMX monitoring will be enabled and exposed on RMI_PORT (default=18983), without any authentication. If this port is opened for inbound traffic in your firewall, then anyone with network access to your Solr nodes will be able to access JMX, which may in turn allow them to upload malicious code for execution on the Solr server.",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2020-01-28T22:26:54Z",
-									Severity:    "HIGH",
-									Summary:     "High severity vulnerability that affects org.apache.solr:solr-core",
-									UpdatedAt:   "2020-01-28T22:26:54Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        9.8,
-										VectorString: "3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "8.3.0",
-								},
-								VulnerableVersionRange: "\u003e= 8.1.1, \u003c= 8.2.0",
-							},
-							{
-								Severity:  "MODERATE",
-								UpdatedAt: "2018-10-19T16:40:55Z",
-								Package: Package{
-									Ecosystem: "MAVEN",
-									Name:      "org.apache.qpid:qpid-broker",
-								},
-								Advisory: Advisory{
-									DatabaseId: 888,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTI2OW0tNjk1eC1qMzRw",
-									GhsaId:     "GHSA-269m-695x-j34p",
-									References: []Reference{
-										{
-											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-15702",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-269m-695x-j34p",
-										},
-										{
-											Type:  "CVE",
-											Value: "CVE-2017-15702",
-										},
-									},
-									Description: "In Apache Qpid Broker-J 0.18 through 0.32, if the broker is configured with different authentication providers on different ports one of which is an HTTP port, then the broker can be tricked by a remote unauthenticated attacker connecting to the HTTP port into using an authentication provider that was configured on a different port. The attacker still needs valid credentials with the authentication provider on the spoofed port. This becomes an issue when the spoofed port has weaker authentication protection (e.g., anonymous access, default accounts) and is normally protected by firewall rules or similar which can be circumvented by this vulnerability. AMQP ports are not affected. Versions 6.0.0 and newer are not affected.",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2018-10-19T16:41:04Z",
-									Severity:    "MODERATE",
-									Summary:     "Moderate severity vulnerability that affects org.apache.qpid:qpid-broker",
-									UpdatedAt:   "2019-07-03T21:02:04Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        9.8,
-										VectorString: "3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "6.0.0",
-								},
-								VulnerableVersionRange: "\u003e= 0.18, \u003c= 0.32",
-							},
-						},
-						PageInfo: PageInfo{
-							EndCursor:   githubql.String("nextCursor"),
-							HasNextPage: true,
-						},
-					},
-				},
-				githubql.String("nextCursor"): {
-					SecurityVulnerabilities: SecurityVulnerabilities{
-						Nodes: []GithubSecurityAdvisory{
-							{
-
-								Severity:  "MODERATE",
-								UpdatedAt: "2019-03-14T15:37:54Z",
-								Package: Package{
-									Ecosystem: "MAVEN",
-									Name:      "org.apache.hive:hive",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1293,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
-									GhsaId:     "GHSA-2g9q-chq2-w8qw",
-									References: []Reference{
-										{
-											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2g9q-chq2-w8qw",
-										},
-										{
-											Type:  "CVE",
-											Value: "CVE-2017-12625",
-										},
-									},
-									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2019-03-14T15:40:16Z",
-									Severity:    "MODERATE",
-									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
-									UpdatedAt:   "2019-07-03T21:02:07Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        4.3,
-										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "2.3.1",
-								},
-								VulnerableVersionRange: "= 2.3.0",
-							},
-							{
-
-								Severity:  "MODERATE",
-								UpdatedAt: "2019-03-14T15:37:54Z",
-								Package: Package{
-									Ecosystem: "MAVEN",
-									Name:      "org.apache.hive:hive",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1293,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
-									GhsaId:     "GHSA-2g9q-chq2-w8qw",
-									References: []Reference{
-										{
-											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2g9q-chq2-w8qw",
-										},
-										{
-											Type:  "CVE",
-											Value: "CVE-2017-12625",
-										},
-									},
-									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2019-03-14T15:40:16Z",
-									Severity:    "MODERATE",
-									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
-									UpdatedAt:   "2019-07-03T21:02:07Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        4.3,
-										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "2.2.1",
-								},
-								VulnerableVersionRange: "= 2.2.0",
-							},
-							{
-
-								Severity:  "MODERATE",
-								UpdatedAt: "2019-03-14T15:37:54Z",
-								Package: Package{
-									Ecosystem: "MAVEN",
-									Name:      "org.apache.hive:hive",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1293,
-									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
-									GhsaId:     "GHSA-2g9q-chq2-w8qw",
-									References: []Reference{
-										{
-											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
-										},
-									},
-									Identifiers: []Identifier{
-										{
-											Type:  "GHSA",
-											Value: "GHSA-2g9q-chq2-w8qw",
-										},
-										{
-											Type:  "CVE",
-											Value: "CVE-2017-12625",
-										},
-									},
-									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
-									Origin:      "UNSPECIFIED",
-									PublishedAt: "2019-03-14T15:40:16Z",
-									Severity:    "MODERATE",
-									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
-									UpdatedAt:   "2019-07-03T21:02:07Z",
-									WithdrawnAt: "",
-									CVSS: GithubCVSS{
-										Score:        4.3,
-										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-									},
-								},
-								FirstPatchedVersion: FirstPatchedVersion{
-									Identifier: "2.1.2",
-								},
-								VulnerableVersionRange: "\u003e= 2.1.0, \u003c 2.1.2",
-							},
-						},
-						PageInfo: PageInfo{
-							EndCursor:   githubql.String(""),
-							HasNextPage: false,
-						},
-					},
-				},
-			},
-			expectedErrorMsg: "",
-		},
-		{
-			name:           "read only filesystem test",
-			appFs:          afero.NewReadOnlyFs(afero.NewOsFs()),
-			inputEcosystem: Composer,
-			goldenFiles:    map[string]string{},
-			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
-				githubql.String(""): {
-					SecurityVulnerabilities: SecurityVulnerabilities{
-						Nodes: []GithubSecurityAdvisory{
-							{
-								Package: Package{
-									Ecosystem: "COMPOSER",
-									Name:      "composer",
-								},
-								Advisory: Advisory{
-									DatabaseId: 1,
-								},
-							},
-						},
-						PageInfo: PageInfo{
-							EndCursor:   githubql.String(""),
-							HasNextPage: false,
-						},
-					},
-				},
-			},
-			expectedErrorMsg: "unable to create a directory: operation not permitted",
+			name:    "sad path",
+			rootDir: "testdata/sad",
+			wantErr: "yaml: unmarshal errors",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := MockClient{
-				Response: tc.inputResponse,
-			}
+			base := afero.NewOsFs()
+			roBase := afero.NewReadOnlyFs(base)
+			ufs := afero.NewCopyOnWriteFs(roBase, afero.NewMemMapFs())
+
 			c := Config{
-				vulnListDir: "/tmp",
-				appFs:       tc.appFs,
-				retry:       0,
-				client:      client,
-			}
-			err := c.update(tc.inputEcosystem)
-			switch {
-			case tc.expectedErrorMsg != "":
-				require.NotNil(t, err, tc.name)
-				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
-				return
-			default:
-				assert.NoError(t, err, tc.name)
+				vulnListDir: "./tmp",
+				cacheDir:    "./cache",
+				appFs:       ufs,
 			}
 
+			err := c.walkDir(tc.rootDir)
+			if tc.wantErr != "" {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr, tc.name)
+				return
+			}
+			assert.NoError(t, err)
+
 			fileCount := 0
-			err = afero.Walk(c.appFs, "/", func(path string, info os.FileInfo, err error) error {
+			err = afero.Walk(c.appFs, "./tmp", func(path string, info os.FileInfo, err error) error {
 				if err != nil {
 					return err
 				}
@@ -478,58 +71,545 @@ func TestConfig_Update(t *testing.T) {
 				}
 				fileCount += 1
 
-				actual, err := afero.ReadFile(c.appFs, path)
-				assert.NoError(t, err, tc.name)
+				got, err := afero.ReadFile(c.appFs, path)
+				assert.NoError(t, err, path)
 
-				goldenPath, ok := tc.goldenFiles[path]
-				if !ok {
-					fmt.Println(path)
-				}
-				assert.True(t, ok, tc.name)
+				relPath, err := filepath.Rel(c.vulnListDir, path)
+				require.NoError(t, err, path)
 
+				goldenPath := filepath.Join(tc.goldenDir, relPath)
 				if *update {
-					err = ioutil.WriteFile(goldenPath, actual, 0666)
+					fmt.Println(goldenPath)
+					err = os.WriteFile(goldenPath, got, 0666)
 					assert.NoError(t, err, tc.name)
 				}
 
-				expected, err := ioutil.ReadFile(goldenPath)
-				assert.NoError(t, err, tc.name)
+				want, err := os.ReadFile(goldenPath)
+				assert.NoError(t, err, goldenPath)
 
-				assert.Equal(t, string(expected), string(actual), tc.name)
+				assert.JSONEq(t, string(want), string(got), tc.name)
 
 				return nil
 			})
-			assert.Equal(t, len(tc.goldenFiles), fileCount, tc.name)
+			assert.Equal(t, tc.wantFileCount, fileCount)
 			assert.NoError(t, err, tc.name)
 		})
 	}
-
 }
 
-func TestConfig_FetchGithubSecurityAdvisories(t *testing.T) {
-	testCases := []struct {
-		name  string
-		retry int
-	}{
-		{
-			name:  "retry test",
-			retry: 1,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			wait = func(i int) time.Duration { return 0 }
-			client := MockClient{
-				Error: errors.New("request error"),
-			}
-			c := Config{
-				vulnListDir: "/tmp",
-				appFs:       afero.NewMemMapFs(),
-				retry:       tc.retry,
-				client:      client,
-			}
-			_, err := c.fetchGithubSecurityAdvisories(Pip)
-			assert.Error(t, err, tc.name)
-		})
-	}
-}
+//
+//type MockClient struct {
+//	Response   map[githubql.String]GetVulnerabilitiesQuery
+//	Error      error
+//	ErrorCount int
+//}
+//
+//func (mc MockClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+//	if mc.Error != nil {
+//		return mc.Error
+//	}
+//
+//	cursor := variables["cursor"].(*githubql.String)
+//	if cursor == (*githubql.String)(nil) {
+//		q.(*GetVulnerabilitiesQuery).SecurityVulnerabilities = mc.Response[githubql.String("")].SecurityVulnerabilities
+//		return nil
+//	}
+//
+//	q.(*GetVulnerabilitiesQuery).SecurityVulnerabilities = mc.Response[*cursor].SecurityVulnerabilities
+//	return nil
+//}
+//
+//func TestConfig_Update(t *testing.T) {
+//	testCases := []struct {
+//		name             string
+//		appFs            afero.Fs
+//		inputEcosystem   SecurityAdvisoryEcosystem
+//		goldenFiles      map[string]string
+//		inputResponse    map[githubql.String]GetVulnerabilitiesQuery
+//		expectedErrorMsg string
+//	}{
+//		{
+//			name:           "positive test",
+//			appFs:          afero.NewMemMapFs(),
+//			inputEcosystem: Composer,
+//			goldenFiles: map[string]string{
+//				"/tmp/ghsa/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json": "testdata/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json",
+//			},
+//			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
+//				githubql.String(""): {
+//					SecurityVulnerabilities: SecurityVulnerabilities{
+//						Nodes: []GithubSecurityAdvisory{
+//							{
+//								Severity:  "LOW",
+//								UpdatedAt: "2020-01-24T21:15:59Z",
+//								Package: Package{
+//									Ecosystem: "COMPOSER",
+//									Name:      "simplesamlphp/simplesamlphp",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1883,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJyM3YtcTl4My03ZzQ2",
+//									GhsaId:     "GHSA-2r3v-q9x3-7g46",
+//									References: []Reference{
+//										{
+//											Url: "https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-2r3v-q9x3-7g46",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2r3v-q9x3-7g46",
+//										},
+//									},
+//									Description: "### Background\nSeveral scripts part of SimpleSAMLphp display a web page with links obtained from the request parameters. This allows us to enhance usability, as the users are presented with links they can follow after completing a certain action, like logging out.\n\n### Description\nThe following scripts were not checking the URLs obtained via the HTTP request before displaying them as the target of links that the user may click on:\n\n- `www/logout.php`\n- `modules/core/www/no_cookie.php`\n\nThe issue allowed attackers to display links targeting a malicious website inside a trusted site running SimpleSAMLphp, due to the lack of security checks involving the `link_href` and `retryURL` HTTP parameters, respectively. The issue was resolved by including a verification of the URLs received in the request against a white list of websites specified in the `trusted.url.domains` configuration option.\n\n### Affected versions\nAll SimpleSAMLphp versions prior to 1.14.4.\n\n### Impact\nA remote attacker could craft a link pointing to a trusted website running SimpleSAMLphp, including a parameter pointing to a malicious website, and try to fool the victim into visiting that website by clicking on a link in the page presented by SimpleSAMLphp.\n\n### Resolution\nUpgrade to the latest version.\n\n### Credit\nThis security issue was discovered and reported by John Page (hyp3rlinx).",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2020-01-24T21:27:16Z",
+//									Severity:    "LOW",
+//									Summary:     "Low severity vulnerability that affects simplesamlphp/simplesamlphp",
+//									UpdatedAt:   "2020-01-24T21:27:17Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        3.7,
+//										VectorString: "3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "1.14.4",
+//								},
+//								VulnerableVersionRange: "\u003c 1.14.4",
+//							},
+//						},
+//						PageInfo: PageInfo{
+//							EndCursor:   githubql.String(""),
+//							HasNextPage: false,
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name:           "positive test with one nil node",
+//			appFs:          afero.NewMemMapFs(),
+//			inputEcosystem: Composer,
+//			goldenFiles: map[string]string{
+//				"/tmp/ghsa/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json": "testdata/composer/simplesamlphp/simplesamlphp/GHSA-2r3v-q9x3-7g46.json",
+//			},
+//			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
+//				githubql.String(""): {
+//					SecurityVulnerabilities: SecurityVulnerabilities{
+//						Nodes: []GithubSecurityAdvisory{
+//							{
+//								Severity:  "LOW",
+//								UpdatedAt: "2020-01-24T21:15:59Z",
+//								Package: Package{
+//									Ecosystem: "COMPOSER",
+//									Name:      "simplesamlphp/simplesamlphp",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1883,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJyM3YtcTl4My03ZzQ2",
+//									GhsaId:     "GHSA-2r3v-q9x3-7g46",
+//									References: []Reference{
+//										{
+//											Url: "https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-2r3v-q9x3-7g46",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2r3v-q9x3-7g46",
+//										},
+//									},
+//									Description: "### Background\nSeveral scripts part of SimpleSAMLphp display a web page with links obtained from the request parameters. This allows us to enhance usability, as the users are presented with links they can follow after completing a certain action, like logging out.\n\n### Description\nThe following scripts were not checking the URLs obtained via the HTTP request before displaying them as the target of links that the user may click on:\n\n- `www/logout.php`\n- `modules/core/www/no_cookie.php`\n\nThe issue allowed attackers to display links targeting a malicious website inside a trusted site running SimpleSAMLphp, due to the lack of security checks involving the `link_href` and `retryURL` HTTP parameters, respectively. The issue was resolved by including a verification of the URLs received in the request against a white list of websites specified in the `trusted.url.domains` configuration option.\n\n### Affected versions\nAll SimpleSAMLphp versions prior to 1.14.4.\n\n### Impact\nA remote attacker could craft a link pointing to a trusted website running SimpleSAMLphp, including a parameter pointing to a malicious website, and try to fool the victim into visiting that website by clicking on a link in the page presented by SimpleSAMLphp.\n\n### Resolution\nUpgrade to the latest version.\n\n### Credit\nThis security issue was discovered and reported by John Page (hyp3rlinx).",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2020-01-24T21:27:16Z",
+//									Severity:    "LOW",
+//									Summary:     "Low severity vulnerability that affects simplesamlphp/simplesamlphp",
+//									UpdatedAt:   "2020-01-24T21:27:17Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        3.7,
+//										VectorString: "3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "1.14.4",
+//								},
+//								VulnerableVersionRange: "\u003c 1.14.4",
+//							},
+//							{}, // nil node
+//						},
+//						PageInfo: PageInfo{
+//							EndCursor:   githubql.String(""),
+//							HasNextPage: false,
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name:           "positive test multi nodes",
+//			appFs:          afero.NewMemMapFs(),
+//			inputEcosystem: Maven,
+//			goldenFiles: map[string]string{
+//				"/tmp/ghsa/maven/org.apache.solr/solr-core/GHSA-2289-pqfq-6wx7.json":   "testdata/maven/org.apache.solr/solr-core/GHSA-2289-pqfq-6wx7.json",
+//				"/tmp/ghsa/maven/org.apache.qpid/qpid-broker/GHSA-269m-695x-j34p.json": "testdata/maven/org.apache.qpid/qpid-broker/GHSA-269m-695x-j34p.json",
+//				"/tmp/ghsa/maven/org.apache.hive/hive/GHSA-2g9q-chq2-w8qw.json":        "testdata/maven/org.apache.hive/hive/GHSA-2g9q-chq2-w8qw.json",
+//			},
+//			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
+//				githubql.String(""): {
+//					SecurityVulnerabilities: SecurityVulnerabilities{
+//						Nodes: []GithubSecurityAdvisory{
+//							{
+//								Severity:  "HIGH",
+//								UpdatedAt: "2020-01-28T22:25:34Z",
+//								Package: Package{
+//									Ecosystem: "MAVEN",
+//									Name:      "org.apache.solr:solr-core",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1892,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTIyODktcHFmcS02d3g3",
+//									GhsaId:     "GHSA-2289-pqfq-6wx7",
+//									References: []Reference{
+//										{
+//											Url: "https://nvd.nist.gov/vuln/detail/CVE-2019-12409",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2289-pqfq-6wx7",
+//										},
+//										{
+//											Type:  "CVE",
+//											Value: "CVE-2019-12409",
+//										},
+//									},
+//									Description: "The 8.1.1 and 8.2.0 releases of Apache Solr contain an insecure setting for the ENABLE_REMOTE_JMX_OPTS configuration option in the default solr.in.sh configuration file shipping with Solr. If you use the default solr.in.sh file from the affected releases, then JMX monitoring will be enabled and exposed on RMI_PORT (default=18983), without any authentication. If this port is opened for inbound traffic in your firewall, then anyone with network access to your Solr nodes will be able to access JMX, which may in turn allow them to upload malicious code for execution on the Solr server.",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2020-01-28T22:26:54Z",
+//									Severity:    "HIGH",
+//									Summary:     "High severity vulnerability that affects org.apache.solr:solr-core",
+//									UpdatedAt:   "2020-01-28T22:26:54Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        9.8,
+//										VectorString: "3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "8.3.0",
+//								},
+//								VulnerableVersionRange: "\u003e= 8.1.1, \u003c= 8.2.0",
+//							},
+//							{
+//								Severity:  "MODERATE",
+//								UpdatedAt: "2018-10-19T16:40:55Z",
+//								Package: Package{
+//									Ecosystem: "MAVEN",
+//									Name:      "org.apache.qpid:qpid-broker",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 888,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTI2OW0tNjk1eC1qMzRw",
+//									GhsaId:     "GHSA-269m-695x-j34p",
+//									References: []Reference{
+//										{
+//											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-15702",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-269m-695x-j34p",
+//										},
+//										{
+//											Type:  "CVE",
+//											Value: "CVE-2017-15702",
+//										},
+//									},
+//									Description: "In Apache Qpid Broker-J 0.18 through 0.32, if the broker is configured with different authentication providers on different ports one of which is an HTTP port, then the broker can be tricked by a remote unauthenticated attacker connecting to the HTTP port into using an authentication provider that was configured on a different port. The attacker still needs valid credentials with the authentication provider on the spoofed port. This becomes an issue when the spoofed port has weaker authentication protection (e.g., anonymous access, default accounts) and is normally protected by firewall rules or similar which can be circumvented by this vulnerability. AMQP ports are not affected. Versions 6.0.0 and newer are not affected.",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2018-10-19T16:41:04Z",
+//									Severity:    "MODERATE",
+//									Summary:     "Moderate severity vulnerability that affects org.apache.qpid:qpid-broker",
+//									UpdatedAt:   "2019-07-03T21:02:04Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        9.8,
+//										VectorString: "3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "6.0.0",
+//								},
+//								VulnerableVersionRange: "\u003e= 0.18, \u003c= 0.32",
+//							},
+//						},
+//						PageInfo: PageInfo{
+//							EndCursor:   githubql.String("nextCursor"),
+//							HasNextPage: true,
+//						},
+//					},
+//				},
+//				githubql.String("nextCursor"): {
+//					SecurityVulnerabilities: SecurityVulnerabilities{
+//						Nodes: []GithubSecurityAdvisory{
+//							{
+//
+//								Severity:  "MODERATE",
+//								UpdatedAt: "2019-03-14T15:37:54Z",
+//								Package: Package{
+//									Ecosystem: "MAVEN",
+//									Name:      "org.apache.hive:hive",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1293,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
+//									GhsaId:     "GHSA-2g9q-chq2-w8qw",
+//									References: []Reference{
+//										{
+//											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2g9q-chq2-w8qw",
+//										},
+//										{
+//											Type:  "CVE",
+//											Value: "CVE-2017-12625",
+//										},
+//									},
+//									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2019-03-14T15:40:16Z",
+//									Severity:    "MODERATE",
+//									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
+//									UpdatedAt:   "2019-07-03T21:02:07Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        4.3,
+//										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "2.3.1",
+//								},
+//								VulnerableVersionRange: "= 2.3.0",
+//							},
+//							{
+//
+//								Severity:  "MODERATE",
+//								UpdatedAt: "2019-03-14T15:37:54Z",
+//								Package: Package{
+//									Ecosystem: "MAVEN",
+//									Name:      "org.apache.hive:hive",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1293,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
+//									GhsaId:     "GHSA-2g9q-chq2-w8qw",
+//									References: []Reference{
+//										{
+//											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2g9q-chq2-w8qw",
+//										},
+//										{
+//											Type:  "CVE",
+//											Value: "CVE-2017-12625",
+//										},
+//									},
+//									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2019-03-14T15:40:16Z",
+//									Severity:    "MODERATE",
+//									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
+//									UpdatedAt:   "2019-07-03T21:02:07Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        4.3,
+//										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "2.2.1",
+//								},
+//								VulnerableVersionRange: "= 2.2.0",
+//							},
+//							{
+//
+//								Severity:  "MODERATE",
+//								UpdatedAt: "2019-03-14T15:37:54Z",
+//								Package: Package{
+//									Ecosystem: "MAVEN",
+//									Name:      "org.apache.hive:hive",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1293,
+//									Id:         "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTJnOXEtY2hxMi13OHF3",
+//									GhsaId:     "GHSA-2g9q-chq2-w8qw",
+//									References: []Reference{
+//										{
+//											Url: "https://nvd.nist.gov/vuln/detail/CVE-2017-12625",
+//										},
+//									},
+//									Identifiers: []Identifier{
+//										{
+//											Type:  "GHSA",
+//											Value: "GHSA-2g9q-chq2-w8qw",
+//										},
+//										{
+//											Type:  "CVE",
+//											Value: "CVE-2017-12625",
+//										},
+//									},
+//									Description: "Apache Hive 2.1.x before 2.1.2, 2.2.x before 2.2.1, and 2.3.x before 2.3.1 expose an interface through which masking policies can be defined on tables or views, e.g., using Apache Ranger. When a view is created over a given table, the policy enforcement does not happen correctly on the table for masked columns.",
+//									Origin:      "UNSPECIFIED",
+//									PublishedAt: "2019-03-14T15:40:16Z",
+//									Severity:    "MODERATE",
+//									Summary:     "Moderate severity vulnerability that affects org.apache.hive:hive, org.apache.hive:hive-exec, and org.apache.hive:hive-service",
+//									UpdatedAt:   "2019-07-03T21:02:07Z",
+//									WithdrawnAt: "",
+//									CVSS: GithubCVSS{
+//										Score:        4.3,
+//										VectorString: "3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+//									},
+//								},
+//								FirstPatchedVersion: FirstPatchedVersion{
+//									Identifier: "2.1.2",
+//								},
+//								VulnerableVersionRange: "\u003e= 2.1.0, \u003c 2.1.2",
+//							},
+//						},
+//						PageInfo: PageInfo{
+//							EndCursor:   githubql.String(""),
+//							HasNextPage: false,
+//						},
+//					},
+//				},
+//			},
+//			expectedErrorMsg: "",
+//		},
+//		{
+//			name:           "read only filesystem test",
+//			appFs:          afero.NewReadOnlyFs(afero.NewOsFs()),
+//			inputEcosystem: Composer,
+//			goldenFiles:    map[string]string{},
+//			inputResponse: map[githubql.String]GetVulnerabilitiesQuery{
+//				githubql.String(""): {
+//					SecurityVulnerabilities: SecurityVulnerabilities{
+//						Nodes: []GithubSecurityAdvisory{
+//							{
+//								Package: Package{
+//									Ecosystem: "COMPOSER",
+//									Name:      "composer",
+//								},
+//								Advisory: Advisory{
+//									DatabaseId: 1,
+//								},
+//							},
+//						},
+//						PageInfo: PageInfo{
+//							EndCursor:   githubql.String(""),
+//							HasNextPage: false,
+//						},
+//					},
+//				},
+//			},
+//			expectedErrorMsg: "unable to create a directory: operation not permitted",
+//		},
+//	}
+//	for _, tc := range testCases {
+//		t.Run(tc.name, func(t *testing.T) {
+//			client := MockClient{
+//				Response: tc.inputResponse,
+//			}
+//			c := Config{
+//				vulnListDir: "/tmp",
+//				appFs:       tc.appFs,
+//				retry:       0,
+//				client:      client,
+//			}
+//			err := c.update(tc.inputEcosystem)
+//			switch {
+//			case tc.expectedErrorMsg != "":
+//				require.NotNil(t, err, tc.name)
+//				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
+//				return
+//			default:
+//				assert.NoError(t, err, tc.name)
+//			}
+//
+//			fileCount := 0
+//			err = afero.Walk(c.appFs, "/", func(path string, info os.FileInfo, err error) error {
+//				if err != nil {
+//					return err
+//				}
+//				if info.IsDir() {
+//					return nil
+//				}
+//				fileCount += 1
+//
+//				actual, err := afero.ReadFile(c.appFs, path)
+//				assert.NoError(t, err, tc.name)
+//
+//				goldenPath, ok := tc.goldenFiles[path]
+//				if !ok {
+//					fmt.Println(path)
+//				}
+//				assert.True(t, ok, tc.name)
+//
+//				if *update {
+//					err = ioutil.WriteFile(goldenPath, actual, 0666)
+//					assert.NoError(t, err, tc.name)
+//				}
+//
+//				expected, err := ioutil.ReadFile(goldenPath)
+//				assert.NoError(t, err, tc.name)
+//
+//				assert.Equal(t, string(expected), string(actual), tc.name)
+//
+//				return nil
+//			})
+//			assert.Equal(t, len(tc.goldenFiles), fileCount, tc.name)
+//			assert.NoError(t, err, tc.name)
+//		})
+//	}
+//
+//}
+//
+//func TestConfig_FetchGithubSecurityAdvisories(t *testing.T) {
+//	testCases := []struct {
+//		name  string
+//		retry int
+//	}{
+//		{
+//			name:  "retry test",
+//			retry: 1,
+//		},
+//	}
+//	for _, tc := range testCases {
+//		t.Run(tc.name, func(t *testing.T) {
+//			wait = func(i int) time.Duration { return 0 }
+//			client := MockClient{
+//				Error: errors.New("request error"),
+//			}
+//			c := Config{
+//				vulnListDir: "/tmp",
+//				appFs:       afero.NewMemMapFs(),
+//				retry:       tc.retry,
+//				client:      client,
+//			}
+//			_, err := c.fetchGithubSecurityAdvisories(Pip)
+//			assert.Error(t, err, tc.name)
+//		})
+//	}
+//}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2020/01/GHSA-g8q7-xv52-hf9f/GHSA-g8q7-xv52-hf9f.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2020/01/GHSA-g8q7-xv52-hf9f/GHSA-g8q7-xv52-hf9f.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-g8q7-xv52-hf9f",
+  "modified": "2021-01-08T21:09:01Z",
+  "published": "2020-01-28T22:37:50Z",
+  "aliases": [
+    "CVE-2020-5227"
+  ],
+  "summary": "Feedgen Vulnerable to XML Denial of Service Attacks",
+  "details": "### Impact\n\nThe *feedgen* library allows supplying XML as content for some of the available fields. This XML will be parsed and integrated into the existing XML tree. During this process, feedgen is vulnerable to [XML Denial of Service Attacks](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses) (e.g. XML Bomb).\n\nThis becomes a concern in particular if feedgen is used to include content from untrused sources and if XML (including XHTML) is directly included instead of providing plain tex content only.\n\n### Patches\n\nThis problem has been fixed in feedgen 0.9.0 which disallows XML entity expansion and external resources.\n\n### Workarounds\n\nUpdating is strongly recommended and should not be problematic. Nevertheless, as a workaround, avoid providing XML directly to feedgen or ensure that no entity expansion is part of the XML. \n\n### References\n\n- [Security Briefs - XML Denial of Service Attacks and Defenses](https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses)\n- [Billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack#cite_note-2)\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n- Open an issue in [lkiesow/python-feedgen](https://github.com/lkiesow/python-feedgen/issues)\n- Send an email to security@lkiesow.de",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "feedgen"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.9.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/lkiesow/python-feedgen/security/advisories/GHSA-g8q7-xv52-hf9f"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-5227"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/lkiesow/python-feedgen/commit/f57a01b20fa4aaaeccfa417f28e66b4084b9d0cf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/T6I5ENUYGFNMIH6ZQ62FZ6VU2WD3SIOI/"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-776"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2020-01-28T22:34:51Z",
+    "nvd_published_at": null
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2021/09/GHSA-hw4v-5x4h-c3xm/GHSA-hw4v-5x4h-c3xm.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2021/09/GHSA-hw4v-5x4h-c3xm/GHSA-hw4v-5x4h-c3xm.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-hw4v-5x4h-c3xm",
+  "modified": "2021-09-03T20:22:28Z",
+  "published": "2021-09-01T18:22:48Z",
+  "aliases": [
+    "CVE-2021-39193"
+  ],
+  "summary": "Transaction validity oversight in pallet-ethereum",
+  "details": "### Impact\n\nA bug in `pallet-ethereum` can cause invalid transactions to be included in the Ethereum block state in `pallet-ethereum` due to not validating the input data size. Any invalid transactions included this way have no possibility to alter the internal Ethereum or Substrate state. The transaction will appear to have be included, but is of no effect as it is rejected by the EVM engine. The impact is further limited by Substrate extrinsic size constraints.\n\n### Patches\n\nPatches are applied in PR #465.\n\n### Workarounds\n\nNone.\n\n### References\n\nPatch PR: https://github.com/paritytech/frontier/pull/465\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n* Open an issue in the [Frontier repo](https://github.com/paritytech/frontier)\n",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "frontier"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.1.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/paritytech/frontier/security/advisories/GHSA-hw4v-5x4h-c3xm"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-39193"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/paritytech/frontier/pull/465"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/paritytech/frontier/pull/465/commits/8a2b890a2fb477d5fedd0e4335b00623832849ae"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/paritytech/frontier/commit/0b962f218f0cdd796dadfe26c3f09e68f7861b26"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/paritytech/frontier/commit/dd112e"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/paritytech/frontier"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-20"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2021-09-01T18:16:10Z",
+    "nvd_published_at": "2021-09-03T18:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2022/05/GHSA-4rgh-jx4f-qfcq/GHSA-4rgh-jx4f-qfcq.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2022/05/GHSA-4rgh-jx4f-qfcq/GHSA-4rgh-jx4f-qfcq.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-4rgh-jx4f-qfcq",
+  "modified": "2022-08-04T21:05:04Z",
+  "published": "2022-05-24T17:37:16Z",
+  "aliases": [
+    "CVE-2020-35669"
+  ],
+  "summary": "http before 0.13.3 vulnerable to header injection",
+  "details": "An issue was discovered in the http package before 0.13.3 for Dart. If the attacker controls the HTTP method and the app is using Request directly, it's possible to achieve CRLF injection in an HTTP request via HTTP header injection. This issue has been addressed in commit abb2bb182 by validating request methods.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Pub",
+        "name": "http"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-35669"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dart-lang/http/issues/511"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dart-lang/http/pull/512"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dart-lang/http/commit/abb2bb182fbd7f03aafd1f889b902d7b3bdb8769"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/dart-lang/http"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dart-lang/http/blob/master/CHANGELOG.md#0133"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pub.dev/packages/http/changelog#0133"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-74"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2022-08-04T21:05:04Z",
+    "nvd_published_at": "2020-12-24T03:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-22m9-m3ww-53h3/GHSA-22m9-m3ww-53h3.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-22m9-m3ww-53h3/GHSA-22m9-m3ww-53h3.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-22m9-m3ww-53h3",
+  "modified": "2023-01-19T21:31:41Z",
+  "published": "2023-01-10T22:19:49Z",
+  "aliases": [
+    "CVE-2023-22487"
+  ],
+  "summary": "Flarum post mentions can be used to read any post on the forum without access control",
+  "details": "Using the mentions feature provided by the flarum/mentions extension, users can mention any post ID on the forum with the special `@\"<username>\"#p<id>` syntax.\n\nThe following behavior never changes no matter if the actor should be able to read the mentioned post or not:\n\nA URL to the mentioned post is inserted into the actor post HTML, leaking its discussion ID and post number.\n\nThe `mentionsPosts` relationship included in the `POST /api/posts` and `PATCH /api/posts/<id>` JSON responses leaks the full JSON:API payload of all mentioned posts without any access control. This includes the content, date, number and attributes added by other extensions.\n\nAn attacker only needs the ability to create new posts on the forum to exploit the vulnerability. This works even if new posts require approval. If they have the ability to edit posts, the attack can be performed even more discreetly by using a single post to scan any size of database and hiding the attack post content afterward.\n\n### Impact\nThe attack allows the leaking of all posts in the forum database, including posts awaiting approval, posts in tags the user has no access to, and private discussions created by other extensions like FriendsOfFlarum Byobu. This also includes non-comment posts like tag changes or renaming events. \n\nThe discussion payload is not leaked but using the mention HTML payload it's possible to extract the discussion ID of all posts and combine all posts back together into their original discussions even if the discussion title remains unknown.\n\nAll Flarum versions prior to `v1.6.3` are affected.\n\n### Patches\nThe vulnerability has been fixed and published as flarum/core v1.6.3. All communities running Flarum have to upgrade as soon as possible to v1.6.3 using:\n\n```\ncomposer update --prefer-dist --no-dev -a -W\n```\nYou can then confirm you run the latest version using:\n\n```\ncomposer show flarum/core\n```\n\n### Workarounds\nDisable the mentions extension.\n\n### For more information\nFor any questions or comments on this vulnerability please visit https://discuss.flarum.org/\n\nFor support questions create a discussion at https://discuss.flarum.org/t/support.\n\nA reminder that if you ever become aware of a security issue in Flarum, please report it to us privately by emailing [security@flarum.org](mailto:security@flarum.org), and we will address it promptly.\n",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "flarum/mentions"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/flarum/framework/security/advisories/GHSA-22m9-m3ww-53h3"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/flarum/framework/commit/ab1c868b978e8b0d09a5d682c54665dae17d0985"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/flarum/framework"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/flarum/framework/releases/tag/v1.6.3"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-284"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-10T22:19:49Z",
+    "nvd_published_at": "2023-01-11T20:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-23c2-gwp5-pxw9/GHSA-23c2-gwp5-pxw9.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-23c2-gwp5-pxw9/GHSA-23c2-gwp5-pxw9.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-23c2-gwp5-pxw9",
+  "modified": "2023-02-10T00:20:24Z",
+  "published": "2023-01-18T18:13:19Z",
+  "aliases": [
+    "CVE-2023-22799"
+  ],
+  "summary": "ReDoS based DoS vulnerability in GlobalID",
+  "details": "There is a ReDoS based DoS vulnerability in the GlobalID gem. This vulnerability has been assigned the CVE identifier CVE-2023-22799.\n\nVersions Affected: >= 0.2.1 Not affected: NOTAFFECTED Fixed Versions: 1.0.1\nImpact\n\nThere is a possible DoS vulnerability in the model name parsing section of the GlobalID gem. Carefully crafted input can cause the regular expression engine to take an unexpected amount of time. All users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nThere are no feasible workarounds for this issue.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    1-0-model-name-redos.patch - Patch for 1.0 series\n",
+  "severity": [
+
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "globalid"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.2.1"
+            },
+            {
+              "fixed": "1.0.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22799"
+    },
+    {
+      "type": "WEB",
+      "url": "https://discuss.rubyonrails.org/t/cve-2023-22799-possible-redos-based-dos-vulnerability-in-globalid/82127"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rails/globalid"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/globalid/releases/tag/v1.0.1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/globalid/CVE-2023-22799.yml"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-1333"
+    ],
+    "severity": "LOW",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-18T18:13:19Z",
+    "nvd_published_at": "2023-02-09T20:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-2jpx-h8j2-g8m4/GHSA-2jpx-h8j2-g8m4.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-2jpx-h8j2-g8m4/GHSA-2jpx-h8j2-g8m4.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-2jpx-h8j2-g8m4",
+  "modified": "2023-02-03T20:46:00Z",
+  "published": "2023-01-26T21:30:18Z",
+  "aliases": [
+    "CVE-2023-24425"
+  ],
+  "summary": "Exposure of system-scoped Kubernetes credentials in Jenkins Kubernetes Credentials Provider Plugin",
+  "details": "Jenkins Kubernetes Credentials Provider Plugin 1.208.v128ee9800c04 and earlier does not set the appropriate context for Kubernetes credentials lookup, allowing attackers with Item/Configure permission to access and potentially capture Kubernetes credentials they are not entitled to.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.cloudbees.jenkins.plugins:kubernetes-credentials-provider"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.209.v862c6e5fb"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24425"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3022"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-27T01:02:39Z",
+    "nvd_published_at": "2023-01-26T21:18:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-2x48-p6cq-5xcw/GHSA-2x48-p6cq-5xcw.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-2x48-p6cq-5xcw/GHSA-2x48-p6cq-5xcw.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-2x48-p6cq-5xcw",
+  "modified": "2023-01-31T01:59:08Z",
+  "published": "2023-01-23T06:30:20Z",
+  "aliases": [
+    "CVE-2022-46959"
+  ],
+  "summary": "Path Traversal in github.com/go-sonic/sonic",
+  "details": "An issue in the component /admin/backups/work-dir of Sonic v1.0.4 allows attackers to execute a directory traversal.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/go-sonic/sonic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.5"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46959"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/go-sonic/sonic/issues/56"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/go-sonic/sonic/pull/61/commits/3b00266a13fa69284f4b3f4b37d29be8f8e02f31"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/go-sonic/sonic"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/go-sonic/sonic/releases/tag/v1.0.5"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-22"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-23T20:37:57Z",
+    "nvd_published_at": "2023-01-23T05:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-33gv-rvgq-gpxp/GHSA-33gv-rvgq-gpxp.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-33gv-rvgq-gpxp/GHSA-33gv-rvgq-gpxp.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-33gv-rvgq-gpxp",
+  "modified": "2023-02-04T00:30:29Z",
+  "published": "2023-01-27T00:30:18Z",
+  "aliases": [
+    "CVE-2023-0493"
+  ],
+  "summary": "HTML injections in BTCPayServer",
+  "details": "Improper Neutralization of Equivalent Special Elements in GitHub repository btcpayserver/btcpayserver prior to 1.7.5.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "BTCPayServer.Client"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.7.5"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0493"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/btcpayserver/btcpayserver/commit/02070d65836cd24627929b3403efbae8de56039a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://huntr.dev/bounties/3a73b45c-6f3e-4536-a327-cdfdbc59896f"
+    },
+    {
+      "type": "WEB",
+      "url": "http://packetstormsecurity.com/files/171732/BTCPay-Server-1.7.4-HTML-Injection.html"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-76"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-02-04T00:30:29Z",
+    "nvd_published_at": "2023-01-26T23:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-36fh-84j7-cv5h/GHSA-36fh-84j7-cv5h.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-36fh-84j7-cv5h/GHSA-36fh-84j7-cv5h.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-36fh-84j7-cv5h",
+  "modified": "2023-03-03T23:25:11Z",
+  "published": "2023-01-29T06:30:52Z",
+  "aliases": [
+    "CVE-2022-48285"
+  ],
+  "summary": "JSZip contains Path Traversal via loadAsync",
+  "details": "loadAsync in JSZip before 3.8.0 allows Directory Traversal via a crafted ZIP archive.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jszip"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-48285"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Stuk/jszip/commit/2edab366119c9ee948357c02f1206c28566cdf15"
+    },
+    {
+      "type": "WEB",
+      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/244499"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/Stuk/jszip"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Stuk/jszip/compare/v3.7.1...v3.8.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.mend.io/vulnerability-database/WS-2023-0004"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-22"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-02-01T18:08:04Z",
+    "nvd_published_at": "2023-01-29T05:15:00Z"
+  }
+}

--- a/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-4r2f-6fm9-2qgh/GHSA-4r2f-6fm9-2qgh.json
+++ b/ghsa/testdata/happy/advisories/github-reviewed/2023/01/GHSA-4r2f-6fm9-2qgh/GHSA-4r2f-6fm9-2qgh.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-4r2f-6fm9-2qgh",
+  "modified": "2023-01-13T19:21:37Z",
+  "published": "2023-01-10T06:30:25Z",
+  "aliases": [
+    "CVE-2017-20166"
+  ],
+  "summary": "Ecto lacks a protection mechanism",
+  "details": "Ecto 2.2.0 lacks a certain protection mechanism associated with the interaction between `is_nil` and `raise`.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Hex",
+        "name": "ecto"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.2.0"
+            },
+            {
+              "fixed": "2.2.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "2.2.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-20166"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elixir-ecto/ecto/pull/2125"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elixir-ecto/ecto/commit/db55b0cba6525c24ebddc88ef9ae0c1c00620250"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-2xxx-fhc8-9qvq"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/elixir-ecto/ecto"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/forum/#!topic/elixir-ecto/0m4NPfg_MMU"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+
+    ],
+    "severity": "CRITICAL",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-10T22:16:53Z",
+    "nvd_published_at": "2023-01-10T06:15:00Z"
+  }
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,10 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"log"
-	"os"
 	"time"
 
-	githubql "github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/vuln-list-update/alma"
@@ -41,8 +37,8 @@ var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
 		"debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, go-vulndb, mariner, kevc, wolfi, chainguard)")
 	vulnListDir  = flag.String("vuln-list-dir", "", "vuln-list dir")
-	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
-	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
+	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad/ghsa)")
+	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad/ghsa)")
 )
 
 func main() {
@@ -113,12 +109,7 @@ func run() error {
 			return xerrors.Errorf("Photon update error: %w", err)
 		}
 	case "ghsa":
-		src := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
-		)
-		httpClient := oauth2.NewClient(context.Background(), src)
-
-		gc := ghsa.NewConfig(githubql.NewClient(httpClient))
+		gc := ghsa.NewConfig(*targetUri, *targetBranch)
 		if err := gc.Update(); err != nil {
 			return xerrors.Errorf("GitHub Security Advisory update error: %w", err)
 		}


### PR DESCRIPTION
## Description
https://github.com/github/advisory-database is open public.
We can get advisories from repository instead of API.

We will also switch to the OSV scheme.

TODO:
- update tests
- add test for advisory with some ecosystems in 1 file (https://github.com/advisories/GHSA-cfgp-2977-2fmm)