### PR TITLE
chore: fall back into vuln-list-reserve

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Check out vuln-list repo
       uses: actions/checkout@v3
       with:
-        repository: ${{ github.repository_owner }}/vuln-list
+        repository: ${{ github.repository_owner }}/vuln-list-tmp
         token: ${{ secrets.ACCESS_TOKEN }}
         path: ${{ env.VULN_LIST_DIR }}
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Check out vuln-list repo
       uses: actions/checkout@v3
       with:
-        repository: ${{ github.repository_owner }}/vuln-list-tmp
+        repository: ${{ github.repository_owner }}/vuln-list-reserve
         token: ${{ secrets.ACCESS_TOKEN }}
         path: ${{ env.VULN_LIST_DIR }}
 


### PR DESCRIPTION
vuln-list is down now, and it is failing to build trivy-db. We need a temporal solution until it will be back.