### PR TITLE
BREAKING CHANGE: extract NVD advisories to separate repo

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,0 +1,40 @@
+name: Update vuln-list-nvd repo
+on:
+  schedule:
+  - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update vuln-list-nvd
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      VULN_LIST_DIR: "vuln-list-nvd"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - name: Check out vuln-list-nvd repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.repository_owner }}/${{ env.VULN_LIST_DIR }}
+        token: ${{ secrets.ACCESS_TOKEN }}
+        path: ${{ env.VULN_LIST_DIR }}
+
+    - name: Setup github user email and name
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
+
+    - name: Compile vuln-list-update
+      run: go build -o vuln-list-update .
+
+    - if: always()
+      name: NVD
+      run: ./update.sh nvd "NVD"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,10 +36,6 @@ jobs:
       run: go build -o vuln-list-update .
 
     - if: always()
-      name: NVD
-      run: ./update.sh nvd "NVD"
-
-    - if: always()
       name: Alpine Issue Tracker
       run: ./update.sh alpine "Alpine Issue Tracker"
 

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -23,7 +23,7 @@ type NVD struct {
 
 const (
 	baseURL     = "https://nvd.nist.gov/feeds/json/cve/1.1"
-	nvdDir      = "nvd"
+	feedDir     = "feed"
 	concurrency = 5
 	wait        = 0
 	retry       = 5
@@ -110,7 +110,7 @@ func save(nvd *NVD) error {
 			continue
 		}
 
-		if err = utils.SaveCVEPerYear(filepath.Join(utils.VulnListDir(), nvdDir), cveID, item); err != nil {
+		if err = utils.SaveCVEPerYear(filepath.Join(utils.VulnListDir(), feedDir), cveID, item); err != nil {
 			return xerrors.Errorf("failed to save NVD CVE detail: %w", err)
 		}
 	}


### PR DESCRIPTION
## Description
The updates and motivations of this PR are the same as https://github.com/aquasecurity/vuln-list-update/pull/217.

## Tests
- https://github.com/DmitriyLewen/vuln-list-update/actions/runs/5666605153
- https://github.com/dmitriylewen/vuln-list-nvd/tree/main


