### PR TITLE
chore: increase k8s open prs limit

### DIFF
--- a/scripts/create_pr.sh
+++ b/scripts/create_pr.sh
@@ -24,7 +24,7 @@ if [[ -n $(git status --porcelain) ]]; then
     PR_BODY="This PR updates $FILE"
 
     # Check if a PR with the same branch name already exists
-    OPEN_PR_COUNT=$(gh pr list --state open --base $BASE_BRANCH --repo "$REPO" | grep "$FILE" | wc -l)
+    OPEN_PR_COUNT=$(gh pr list --state open --base $BASE_BRANCH --repo "$REPO"  --limit 50| grep "$FILE" | wc -l)
 
     if [ "$OPEN_PR_COUNT" != 0 ]; then
       echo "PR for $FILE already exists, skipping."


### PR DESCRIPTION
increase `gh list pr` page limit when query for open PRs
fix this [error](https://github.com/aquasecurity/vuln-list-update/actions/runs/6368520330/job/17287946530) 

I have increased `limit to 50` (enough for now , default limit is 30) should be ok for now I assume it will happen only for initial db creation 