### PR TITLE
feat(debian/tracker): add TEMP entry instead of CVE-yyyy-XXXX

### DIFF
--- a/debian/tracker/debian_test.go
+++ b/debian/tracker/debian_test.go
@@ -154,6 +154,64 @@ func TestClient_Update(t *testing.T) {
 						},
 					},
 				},
+				filepath.Join("CVE", "TEMP", "TEMP-1053115-9454E3.json"): {
+					Header: &tracker.Header{
+						Original:    "CVE-2023-XXXX [code execution via malformed XTGETTCAP]",
+						ID:          "TEMP-1053115-9454E3",
+						Description: "[code execution via malformed XTGETTCAP]",
+					},
+					Annotations: []*tracker.Annotation{
+						{
+							Original: "- foot 1.15.3-2 (bug #1053115)",
+							Type:     "package",
+							Package:  "foot",
+							Kind:     "fixed",
+							Version:  "1.15.3-2",
+							BugNo:    1053115,
+						},
+						{
+							Original: "[bookworm] - foot 1.13.1-2+deb12u1",
+							Type:     "package",
+							Release:  "bookworm",
+							Package:  "foot",
+							Kind:     "fixed",
+							Version:  "1.13.1-2+deb12u1",
+						},
+						{
+							Original:    "[bullseye] - foot <no-dsa> (Minor issue)",
+							Type:        "package",
+							Release:     "bullseye",
+							Package:     "foot",
+							Kind:        "no-dsa",
+							Description: "Minor issue",
+						},
+						{
+							Original:    "NOTE: https://codeberg.org/dnkl/foot/commit/8a5f2915e9d327d1517d1da49ce7e2303fe61d36",
+							Type:        "NOTE",
+							Description: "https://codeberg.org/dnkl/foot/commit/8a5f2915e9d327d1517d1da49ce7e2303fe61d36",
+						},
+					},
+				},
+				filepath.Join("CVE", "TEMP", "TEMP-0000000-556898.json"): {
+					Header: &tracker.Header{
+						Original:    "CVE-2023-XXXX [Other security issues from wordpress 6.3.2]",
+						ID:          "TEMP-0000000-556898",
+						Description: "[Other security issues from wordpress 6.3.2]",
+					},
+					Annotations: []*tracker.Annotation{
+						{
+							Original: "- wordpress <unfixed>",
+							Type:     "package",
+							Package:  "wordpress",
+							Kind:     "unfixed",
+						},
+						{
+							Original:    "NOTE: https://wordpress.org/documentation/wordpress-version/version-6-3-2/",
+							Type:        "NOTE",
+							Description: "https://wordpress.org/documentation/wordpress-version/version-6-3-2/",
+						},
+					},
+				},
 			},
 			wantDists: map[string]tracker.Distribution{
 				"stretch": {

--- a/debian/tracker/testdata/happy/data/CVE/list
+++ b/debian/tracker/testdata/happy/data/CVE/list
@@ -1,3 +1,11 @@
+CVE-2023-XXXX [code execution via malformed XTGETTCAP]
+	- foot 1.15.3-2 (bug #1053115)
+	[bookworm] - foot 1.13.1-2+deb12u1
+	[bullseye] - foot <no-dsa> (Minor issue)
+	NOTE: https://codeberg.org/dnkl/foot/commit/8a5f2915e9d327d1517d1da49ce7e2303fe61d36
+CVE-2023-XXXX [Other security issues from wordpress 6.3.2]
+	- wordpress <unfixed>
+	NOTE: https://wordpress.org/documentation/wordpress-version/version-6-3-2/
 CVE-2021-36980 (Open vSwitch (aka openvswitch) 2.11.0 through 2.15.0 has a use-after-f ...)
         TODO: check
 CVE-2021-36383 (Xen Orchestra (with xo-web through 5.80.0 and xo-server through 5.84.0 ...)


### PR DESCRIPTION
There are multiple entries called `CVE-yyyy-XXXX` in `CVE/list`.
ref. https://salsa.debian.org/search?search=XXXX&nav_source=navbar&project_id=555&group_id=2102&search_code=true&repository_ref=master

However, the current vuln-list-update does not consider them, and only one is saved as `vuln-list-debian/tracker/CVE/yyyy/CVE-yyyy-XXXX.json`.
ref. https://github.com/search?q=repo%3Aaquasecurity%2Fvuln-list-debian%20XXXX&type=code

If you look at these entries on the Debian Security Tracker on the web, they will be converted to entries called TEMP.
ref. https://security-tracker.debian.org/tracker/data/fake-names

The conversion method is as follows.
https://salsa.debian.org/security-tracker-team/security-tracker/-/blob/50ca55fb66ec7592f9bc1053a11dbf0bd50ee425/lib/python/bugs.py#L402-408

This PR changes to save to `vuln-list-debian/tracker/CVE/TEMP/TEMP-{Debian Bug Number}-{md5sum(description)}.json` in case of `CVE-yyyy-XXXX`. 