### PR TITLE
fix: revert changes on error

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,4 +1,13 @@
-#!/bin/bash -eu
+#!/bin/bash -eEu
+
+HEAD=$(git rev-parse HEAD)
+shopt -s inherit_errexit
+on_error() {
+    echo "[Err] Revert changes" >&2
+    git reset --hard "${HEAD}"
+    exit 1
+}
+trap on_error ERR
 
 TARGET=$1
 COMMIT_MSG=$2


### PR DESCRIPTION
## Description
If the update script fails midway through, the state of the directory remains intact and is accidentally committed in another step. Then, it will fail to build trivy-db. Failure of vuln-list-update is expected and must not affect trivy-db builds. The changes should be reverted in case of an error.