### PR TITLE
fix(mariner): replace CBL-MarinerVulnerabilityData with AzureLinuxVulnerabilityData

### DIFF
--- a/mariner/mariner.go
+++ b/mariner/mariner.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	repoURL = "https://github.com/microsoft/CBL-MarinerVulnerabilityData/archive/refs/heads/main.tar.gz//CBL-MarinerVulnerabilityData-main"
+	repoURL = "https://github.com/microsoft/AzureLinuxVulnerabilityData/archive/refs/heads/main.tar.gz//AzureLinuxVulnerabilityData-main"
 	cblDir  = "mariner" // CBL-Mariner Vulnerability Data
 	retry   = 3
 


### PR DESCRIPTION
Microsoft changed the repository name from CBL-MarinerVulnerabilityData to AzureLinuxVulnerabilityData, and it broke our pipeline.
https://github.com/microsoft/AzureLinuxVulnerabilityData
