### PR TITLE
Add module for updating openEuler os cves

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -98,3 +98,7 @@ jobs:
     - if: always()
       name: Chainguard Secdb
       run: ./scripts/update.sh chainguard "Chainguard Security Data"
+    
+    - if: always()
+      name: openEuler CVE
+      run: ./scripts/update.sh openeuler "openEuler CVE Data"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/aquasecurity/vuln-list/
 $ vuln-list-update -h
 Usage of vuln-list-update:
   -target string
-    	update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, debian-oval, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, go-vulndb, mariner, kevc, wolfi, chainguard)
+    	update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, debian-oval, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, go-vulndb, mariner, kevc, wolfi, chainguard, openeuler )
   -target-branch string
     	alternative repository branch (only glad)
   -target-uri string

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aquasecurity/vuln-list-update/kevc"
 	"github.com/aquasecurity/vuln-list-update/mariner"
 	"github.com/aquasecurity/vuln-list-update/nvd"
+	"github.com/aquasecurity/vuln-list-update/openeuler"
 	oracleoval "github.com/aquasecurity/vuln-list-update/oracle/oval"
 	"github.com/aquasecurity/vuln-list-update/osv"
 	"github.com/aquasecurity/vuln-list-update/photon"
@@ -38,7 +39,7 @@ import (
 
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
-		"debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, k8s)")
+		"debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, k8s, openeuler)")
 	vulnListDir  = flag.String("vuln-list-dir", "", "vuln-list dir")
 	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
 	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
@@ -175,6 +176,11 @@ func run() error {
 		ku := k8s.NewUpdater()
 		if err := ku.Update(); err != nil {
 			return xerrors.Errorf("k8s update error: %w", err)
+		}
+	case "openeuler":
+		ec := openeuler.NewConfig()
+		if err := ec.Update(); err != nil {
+			return xerrors.Errorf("openEuler CVE update error: %w", err)
 		}
 	default:
 		return xerrors.New("unknown target")

--- a/openeuler/openeuler.go
+++ b/openeuler/openeuler.go
@@ -1,0 +1,133 @@
+package openeuler
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/cheggaaa/pb"
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+var (
+	cvrfURL      = "https://repo.openeuler.org/security/data/cvrf"
+	retry        = 5
+	concurrency  = 20
+	wait         = 1
+	cvrfDir      = "cvrf"
+	openeulerDir = "openeuler"
+)
+
+type Config struct {
+	VulnListDir string
+	URL         string
+	AppFs       afero.Fs
+	Retry       int
+}
+
+func NewConfig() Config {
+	return Config{
+		VulnListDir: utils.VulnListDir(),
+		URL:         cvrfURL,
+		AppFs:       afero.NewOsFs(),
+		Retry:       retry,
+	}
+}
+
+func (c Config) Update() error {
+	log.Print("Fetching openEuler CVRF data...")
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return xerrors.Errorf("failed to parse openEuler URL: %w", err)
+	}
+	baseURL := u.Path
+	u.Path = path.Join(baseURL, "index.txt")
+
+	res, err := utils.FetchURL(u.String(), "", retry)
+	if err != nil {
+		return xerrors.Errorf("Cannot download openEuler CVRF list: %v", err)
+	}
+	lines := strings.Split(string(res), "\n")
+	cvrfUrlsMap := make(map[string][]string)
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "/", 2)
+		u.Path = path.Join(baseURL, line)
+		cvrfUrlsMap[parts[0]] = append(cvrfUrlsMap[parts[0]], u.String())
+	}
+
+	for year, urls := range cvrfUrlsMap {
+		err = c.update(year, urls)
+		if err != nil {
+			return xerrors.Errorf("failed Update openEuler CVRF: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c Config) update(year string, urls []string) error {
+	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, retry)
+	if err != nil {
+		log.Printf("failed to fetch CVRF data from repo.openEuler.org, err: %s", err)
+	}
+
+	var cvrfs []Cvrf
+	for _, cvrfXml := range cvrfXmls {
+		var cv Cvrf
+		if len(cvrfXml) == 0 {
+			log.Println("empty CVRF xml")
+			continue
+		}
+
+		if !utf8.Valid(cvrfXml) {
+			log.Println("invalid UTF-8")
+			cvrfXml = []byte(strings.ToValidUTF8(string(cvrfXml), ""))
+		}
+
+		err = xml.Unmarshal(cvrfXml, &cv)
+		if err != nil {
+			return xerrors.Errorf("failed to decode openEuler cvrf XML: %w", err)
+		}
+		cvrfs = append(cvrfs, cv)
+	}
+
+	dir := filepath.Join(cvrfDir, openeulerDir, year)
+	log.Printf("Fetching openEuler CVRF %s data into %s ...", year, dir)
+
+	bar := pb.StartNew(len(cvrfs))
+	for _, cvrf := range cvrfs {
+		yearDir := filepath.Join(c.VulnListDir, dir)
+		if err = c.saveCvrf(yearDir, cvrf.Tracking.ID, cvrf); err != nil {
+			return xerrors.Errorf("failed to save CVRF: %w", err)
+		}
+		bar.Increment()
+	}
+	bar.Finish()
+
+	return nil
+}
+
+func (c Config) saveCvrf(dirName string, cvrfID string, data interface{}) error {
+	substrings := strings.Split(cvrfID, "-")
+	if len(substrings) < 4 {
+		log.Printf("invalid CVRF-ID format: %s", cvrfID)
+		return nil
+	}
+
+	fileName := fmt.Sprintf("%s.json", cvrfID)
+	if err := utils.WriteJSON(c.AppFs, dirName, fileName, data); err != nil {
+		return xerrors.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}

--- a/openeuler/openeuler_test.go
+++ b/openeuler/openeuler_test.go
@@ -1,0 +1,169 @@
+package openeuler_test
+
+import (
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/vuln-list-update/openeuler"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func TestConfig_Update(t *testing.T) {
+	testCases := []struct {
+		name             string
+		appFs            afero.Fs
+		xmlFileNames     map[string]string
+		goldenFiles      map[string]string
+		expectedErrorMsg string
+	}{
+		{
+			name:  "positive test sles",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/security/data/cvrf/index.txt":                            "testdata/index.txt",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1033.xml": "testdata/cvrf-openEuler-SA-2021-1033.xml",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1202.xml": "testdata/cvrf-openEuler-SA-2021-1202.xml",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1480.xml": "testdata/cvrf-openEuler-SA-2021-1480.xml",
+				"/security/data/cvrf/2022/cvrf-openEuler-SA-2022-1485.xml": "testdata/cvrf-openEuler-SA-2022-1485.xml",
+				"/security/data/cvrf/2022/cvrf-openEuler-SA-2022-1580.xml": "testdata/cvrf-openEuler-SA-2022-1580.xml",
+				"/security/data/cvrf/2022/cvrf-openEuler-SA-2022-1704.xml": "testdata/cvrf-openEuler-SA-2022-1704.xml",
+				"/security/data/cvrf/2023/cvrf-openEuler-SA-2023-1006.xml": "testdata/cvrf-openEuler-SA-2023-1006.xml",
+				"/security/data/cvrf/2023/cvrf-openEuler-SA-2023-1010.xml": "testdata/cvrf-openEuler-SA-2023-1010.xml",
+				"/security/data/cvrf/2023/cvrf-openEuler-SA-2023-1374.xml": "testdata/cvrf-openEuler-SA-2023-1374.xml",
+				"/security/data/cvrf/2024/cvrf-openEuler-SA-2024-1151.xml": "testdata/cvrf-openEuler-SA-2024-1151.xml",
+				"/security/data/cvrf/2024/cvrf-openEuler-SA-2024-1295.xml": "testdata/cvrf-openEuler-SA-2024-1295.xml",
+				"/security/data/cvrf/2024/cvrf-openEuler-SA-2024-1349.xml": "testdata/cvrf-openEuler-SA-2024-1349.xml",
+				"/security/data/cvrf/2022/cvrf-openEuler-SA-2022-1693.xml": "testdata/cvrf-openEuler-SA-2022-1693.xml",
+			},
+			goldenFiles: map[string]string{
+				"/tmp/cvrf/openeuler/2021/openEuler-SA-2021-1033.json": "testdata/golden/openEuler-SA-2021-1033.json",
+				"/tmp/cvrf/openeuler/2021/openEuler-SA-2021-1202.json": "testdata/golden/openEuler-SA-2021-1202.json",
+				"/tmp/cvrf/openeuler/2021/openEuler-SA-2021-1480.json": "testdata/golden/openEuler-SA-2021-1480.json",
+				"/tmp/cvrf/openeuler/2022/openEuler-SA-2022-1485.json": "testdata/golden/openEuler-SA-2022-1485.json",
+				"/tmp/cvrf/openeuler/2022/openEuler-SA-2022-1580.json": "testdata/golden/openEuler-SA-2022-1580.json",
+				"/tmp/cvrf/openeuler/2022/openEuler-SA-2022-1704.json": "testdata/golden/openEuler-SA-2022-1704.json",
+				"/tmp/cvrf/openeuler/2023/openEuler-SA-2023-1006.json": "testdata/golden/openEuler-SA-2023-1006.json",
+				"/tmp/cvrf/openeuler/2023/openEuler-SA-2023-1010.json": "testdata/golden/openEuler-SA-2023-1010.json",
+				"/tmp/cvrf/openeuler/2023/openEuler-SA-2023-1374.json": "testdata/golden/openEuler-SA-2023-1374.json",
+				"/tmp/cvrf/openeuler/2024/openEuler-SA-2024-1151.json": "testdata/golden/openEuler-SA-2024-1151.json",
+				"/tmp/cvrf/openeuler/2024/openEuler-SA-2024-1295.json": "testdata/golden/openEuler-SA-2024-1295.json",
+				"/tmp/cvrf/openeuler/2024/openEuler-SA-2024-1349.json": "testdata/golden/openEuler-SA-2024-1349.json",
+				"/tmp/cvrf/openeuler/2022/openEuler-SA-2022-1693.json": "testdata/golden/openEuler-SA-2022-1693.json",
+			},
+		},
+		{
+			name:  "invalid filesystem write read only path",
+			appFs: afero.NewReadOnlyFs(afero.NewOsFs()),
+			xmlFileNames: map[string]string{
+				"/security/data/cvrf/index.txt":                            "testdata/invalid-index.txt",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1202.xml": "testdata/golden/openEuler-SA-2021-1202.json",
+			},
+			goldenFiles:      map[string]string{},
+			expectedErrorMsg: "failed Update openEuler CVRF: failed to decode openEuler cvrf XML: EOF",
+		},
+		{
+			name:  "empty file format",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/security/data/cvrf/index.txt":                            "testdata/invalid-index.txt",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1202.xml": "testdata/EOF.txt",
+			},
+			goldenFiles:      map[string]string{},
+			expectedErrorMsg: "",
+		},
+		{
+			name:  "invalid file format",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/security/data/cvrf/index.txt":                            "testdata/invalid-index.txt",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1202.xml": "testdata/invalid.txt",
+			},
+			goldenFiles:      map[string]string{},
+			expectedErrorMsg: "failed Update openEuler CVRF: failed to decode openEuler cvrf XML: EOF",
+		},
+		{
+			name:  "broken XML",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/security/data/cvrf/index.txt":                            "testdata/invalid-index.txt",
+				"/security/data/cvrf/2021/cvrf-openEuler-SA-2021-1202.xml": "testdata/broken-cvrf.xml",
+			},
+			goldenFiles:      map[string]string{},
+			expectedErrorMsg: "failed Update openEuler CVRF: failed to decode openEuler cvrf XML: XML syntax error on line 180: unexpected EOF",
+		},
+	}
+	for _, tc := range testCases {
+		t.Log("Entering...")
+		t.Run(tc.name, func(t *testing.T) {
+			t.Log("http ready to start...")
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				filePath, ok := tc.xmlFileNames[r.URL.Path]
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				b, err := os.ReadFile(filePath)
+				assert.NoError(t, err, tc.name)
+				_, err = w.Write(b)
+				assert.NoError(t, err, tc.name)
+			}))
+			t.Log("http started!")
+			defer ts.Close()
+			url := ts.URL + "/security/data/cvrf/"
+			c := openeuler.Config{
+				VulnListDir: "/tmp",
+				URL:         url,
+				AppFs:       tc.appFs,
+				Retry:       0,
+			}
+			t.Log("updating...")
+			err := c.Update()
+			switch {
+			case tc.expectedErrorMsg != "":
+				require.NotNil(t, err, tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
+				return
+			default:
+				assert.NoError(t, err, tc.name)
+			}
+
+			fileCount := 0
+			err = afero.Walk(c.AppFs, "/", func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				fileCount += 1
+
+				actual, err := afero.ReadFile(c.AppFs, path)
+				require.NoError(t, err, tc.name)
+
+				goldenPath, ok := tc.goldenFiles[path]
+				assert.True(t, ok, tc.name)
+				if *update {
+					err = os.WriteFile(goldenPath, actual, 0666)
+					assert.NoError(t, err, tc.name)
+				}
+				expected, err := os.ReadFile(goldenPath)
+				assert.NoError(t, err, tc.name)
+
+				assert.Equal(t, string(expected), string(actual), tc.name)
+
+				return nil
+			})
+			assert.NoError(t, err, tc.name)
+			assert.Equal(t, len(tc.goldenFiles), fileCount, tc.name)
+		})
+	}
+
+}

--- a/openeuler/testdata/broken-cvrf.xml
+++ b/openeuler/testdata/broken-cvrf.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2021-1202</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2021-06-07</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2021-06-07</InitialReleaseDate>
+		<CurrentReleaseDate>2021-06-07</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2021-06-07</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">libxml2 security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">This library allows to manipulate XML files. It includes support to read, modify and write XML and HTML files. There is DTDs support this includes parsing and validation even with complex DtDs, either at parse time or later once the document has been modified. The output can be a simple SAX stream or and in-memory DOM like representations. In this case one can use the built-in XPath and XPointer implementation to select sub nodes or ranges. A flexible Input/Output mechanism is available, with existing HTTP and FTP modules and combined to an URI library.
+
+Security Fix(es):
+
+A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.(CVE-2021-3537)
+
+There&apos;s a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.(CVE-2021-3518)
+
+There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.(CVE-2021-3517)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">libxml2</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3537</URL>
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3518</URL>
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3517</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3537</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3518</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3517</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="libxml2-debugsource-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debugsource-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debuginfo-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debuginfo-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-devel-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-devel-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="libxml2-help-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-help-2.9.10-16.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debugsource-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debugsource-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debuginfo-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debuginfo-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-devel-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-devel-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3537</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">There&apos;s a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3518</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>8.8</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="3" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="3" xml:lang="en">There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3517</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>8.6</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+    <Vulnerability>

--- a/openeuler/testdata/cvrf-openEuler-SA-2021-1033.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2021-1033.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2021-1033</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2021-02-05</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2021-02-05</InitialReleaseDate>
+		<CurrentReleaseDate>2021-02-05</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2021-02-05</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">sane-backends security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">SANE (Scanner Access Now Easy) is a sane and simple interface to both local and networked scanners and other image acquisition devices like digital still and video cameras.\r\n\r\n
+Security Fix(es):\r\n\r\n
+A NULL pointer dereference in sanei_epson_net_read in SANE Backends before 1.0.30 allows a malicious device connected to the same local network as the victim to cause a denial of service, aka GHSL-2020-075.(CVE-2020-12867)\r\n\r\n</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1.\r\n\r\n
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">sane-backends</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1033</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2020-12867</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2020-12867</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">openEuler-20.03-LTS</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debuginfo-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-debuginfo-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debugsource-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-debugsource-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-devel-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-devel-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-libs-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-libs-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-cameras-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-drivers-cameras-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-scanners-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-drivers-scanners-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debuginfo-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-debuginfo-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debugsource-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-debugsource-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-devel-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-devel-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-libs-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-libs-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-cameras-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-drivers-cameras-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-scanners-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-drivers-scanners-1.0.28-9.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-help-1.0.28-9.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-help-1.0.28-9.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-1.0.28-9.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-1.0.28-9.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debuginfo-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-debuginfo-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debugsource-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-debugsource-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-devel-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-devel-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-libs-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-libs-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-cameras-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-drivers-cameras-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-scanners-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS">sane-backends-drivers-scanners-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debuginfo-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-debuginfo-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-debugsource-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-debugsource-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-devel-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-devel-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-libs-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-libs-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-cameras-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-drivers-cameras-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="sane-backends-drivers-scanners-1.0.28-9" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">sane-backends-drivers-scanners-1.0.28-9.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">A NULL pointer dereference in sanei_epson_net_read in SANE Backends before 1.0.30 allows a malicious device connected to the same local network as the victim to cause a denial of service, aka GHSL-2020-075.</Note>
+		</Notes>
+		<ReleaseDate>2021-02-05</ReleaseDate>
+		<CVE>CVE-2020-12867</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.5</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>sane-backends security update</Description>
+				<DATE>2021-02-05</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1033</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2021-1202.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2021-1202.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2021-1202</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2021-06-07</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2021-06-07</InitialReleaseDate>
+		<CurrentReleaseDate>2021-06-07</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2021-06-07</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">libxml2 security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">This library allows to manipulate XML files. It includes support to read, modify and write XML and HTML files. There is DTDs support this includes parsing and validation even with complex DtDs, either at parse time or later once the document has been modified. The output can be a simple SAX stream or and in-memory DOM like representations. In this case one can use the built-in XPath and XPointer implementation to select sub nodes or ranges. A flexible Input/Output mechanism is available, with existing HTTP and FTP modules and combined to an URI library.
+
+Security Fix(es):
+
+A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.(CVE-2021-3537)
+
+There&apos;s a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.(CVE-2021-3518)
+
+There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.(CVE-2021-3517)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for libxml2 is now available for openEuler-20.03-LTS-SP1.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">libxml2</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3537</URL>
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3518</URL>
+			<URL>https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3517</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3537</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3518</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-3517</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="libxml2-debugsource-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debugsource-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debuginfo-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debuginfo-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-devel-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-devel-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="libxml2-help-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-help-2.9.10-16.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debugsource-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debugsource-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-libxml2-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-libxml2-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-debuginfo-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-debuginfo-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libxml2-devel-2.9.10-16" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">libxml2-devel-2.9.10-16.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3537</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">There&apos;s a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3518</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>8.8</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="3" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="3" xml:lang="en">There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.</Note>
+		</Notes>
+		<ReleaseDate>2021-06-07</ReleaseDate>
+		<CVE>CVE-2021-3517</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>8.6</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>libxml2 security update</Description>
+				<DATE>2021-06-07</DATE>
+				<URL>https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2021-1480.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2021-1480.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2021-1480</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2021-12-31</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2021-12-31</InitialReleaseDate>
+		<CurrentReleaseDate>2021-12-31</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2021-12-31</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">rubygem-bundler security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">Library and utilities to manage a Ruby application's gem dependencies.
+
+Security Fix(es):
+
+`Bundler` is a package for managing application dependencies in Ruby. In `bundler` versions before 2.2.33, when working with untrusted and apparently harmless `Gemfile`&apos;s, it is not expected that they lead to execution of external code, unless that&apos;s explicit in the ruby code inside the `Gemfile` itself. However, if the `Gemfile` includes `gem` entries that use the `git` option with invalid, but seemingly harmless, values with a leading dash, this can be False. To handle dependencies that come from a Git repository instead of a registry, Bundler uses various commands, such as `git clone`. These commands are being constructed using user input (e.g. the repository URL). When building the commands, Bundler versions before 2.2.33 correctly avoid Command Injection vulnerabilities by passing an array of arguments instead of a command string. However, there is the possibility that a user input starts with a dash (`-`) and is therefore treated as an optional argument instead of a positional one. This can lead to Code Execution because some of the commands have options that can be leveraged to run arbitrary executables. Since this value comes from the `Gemfile` file, it can contain any character, including a leading dash. To exploit this vulnerability, an attacker has to craft a directory containing a `Gemfile` file that declares a dependency that is located in a Git repository. This dependency has to have a Git URL in the form of `-u./payload`. This URL will be used to construct a Git clone command but will be interpreted as the upload-pack argument. Then this directory needs to be shared with the victim, who then needs to run a command that evaluates the Gemfile, such as `bundle lock`, inside. This vulnerability can lead to Arbitrary Code Execution, which could potentially lead to the takeover of the system. However, the exploitability is very low, because it requires a lot of user interaction. Bundler 2.2.33 has patched this problem by inserting `--` as an argument before any positional arguments to those Git commands that were affected by this issue. Regardless of whether users can upgrade or not, they should review any untrustred `Gemfile`&apos;s before running any `bundler` commands that may read them, since they can contain arbitrary ruby code.(CVE-2021-43809)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">rubygem-bundler</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1480</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-43809</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-43809</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">openEuler-20.03-LTS-SP2</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="rubygem-bundler-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">rubygem-bundler-2.2.33-1.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="rubygem-bundler-help-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">rubygem-bundler-help-2.2.33-1.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="rubygem-bundler-help-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">rubygem-bundler-help-2.2.33-1.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="rubygem-bundler-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">rubygem-bundler-2.2.33-1.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="rubygem-bundler-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">rubygem-bundler-2.2.33-1.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="rubygem-bundler-2.2.33-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">rubygem-bundler-2.2.33-1.oe1.src.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">`Bundler` is a package for managing application dependencies in Ruby. In `bundler` versions before 2.2.33, when working with untrusted and apparently harmless `Gemfile` s, it is not expected that they lead to execution of external code, unless that s explicit in the ruby code inside the `Gemfile` itself. However, if the `Gemfile` includes `gem` entries that use the `git` option with invalid, but seemingly harmless, values with a leading dash, this can be False. To handle dependencies that come from a Git repository instead of a registry, Bundler uses various commands, such as `git clone`. These commands are being constructed using user input (e.g. the repository URL). When building the commands, Bundler versions before 2.2.33 correctly avoid Command Injection vulnerabilities by passing an array of arguments instead of a command string. However, there is the possibility that a user input starts with a dash (`-`) and is therefore treated as an optional argument instead of a positional one. This can lead to Code Execution because some of the commands have options that can be leveraged to run arbitrary executables. Since this value comes from the `Gemfile` file, it can contain any character, including a leading dash. To exploit this vulnerability, an attacker has to craft a directory containing a `Gemfile` file that declares a dependency that is located in a Git repository. This dependency has to have a Git URL in the form of `-u./payload`. This URL will be used to construct a Git clone command but will be interpreted as the upload-pack argument. Then this directory needs to be shared with the victim, who then needs to run a command that evaluates the Gemfile, such as `bundle lock`, inside. This vulnerability can lead to Arbitrary Code Execution, which could potentially lead to the takeover of the system. However, the exploitability is very low, because it requires a lot of user interaction. Bundler 2.2.33 has patched this problem by inserting `--` as an argument before any positional arguments to those Git commands that were affected by this issue. Regardless of whether users can upgrade or not, they should review any untrustred `Gemfile` s before running any `bundler` commands that may read them, since they can contain arbitrary ruby code.</Note>
+		</Notes>
+		<ReleaseDate>2021-12-31</ReleaseDate>
+		<CVE>CVE-2021-43809</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.3</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>rubygem-bundler security update</Description>
+				<DATE>2021-12-31</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1480</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2022-1485.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2022-1485.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2022-1485</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2022-01-07</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2022-01-07</InitialReleaseDate>
+		<CurrentReleaseDate>2022-01-07</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2022-01-07</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">numpy security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">A fast multidimensional array facility for Python.
+
+Security Fix(es):
+
+Buffer overflow in the array_from_pyobj function of fortranobject.c in NumPy &lt; 1.19, which allows attackers to conduct a Denial of Service attacks by carefully constructing an array with negative values.(CVE-2021-41496)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">numpy</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1485</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-41496</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-41496</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">openEuler-20.03-LTS-SP2</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">numpy-debugsource-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python3-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python2-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">numpy-debugsource-1.16.5-4.oe1.aarch64.rpm</FullProductName>			
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python2-numpy-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">numpy-debugsource-1.16.5-4.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">numpy-1.16.5-4.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">numpy-1.16.5-4.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">numpy-1.16.5-4.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">numpy-debugsource-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python2-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python3-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">numpy-debugsource-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python2-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debugsource-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">numpy-debugsource-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python2-numpy-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python2-numpy-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="numpy-debuginfo-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-numpy-f2py-1.16.5-4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">Buffer overflow in the array_from_pyobj function of fortranobject.c in NumPy &lt; 1.19, which allows attackers to conduct a Denial of Service attacks by carefully constructing an array with negative values.</Note>
+		</Notes>
+		<ReleaseDate>2022-01-07</ReleaseDate>
+		<CVE>CVE-2021-41496</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP2</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.5</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>numpy security update</Description>
+				<DATE>2022-01-07</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1485</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2022-1580.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2022-1580.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2022-1580</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2022-03-19</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2022-03-19</InitialReleaseDate>
+		<CurrentReleaseDate>2022-03-19</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2022-03-19</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">vim security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">Vim is an advanced text editor that seeks to provide the power of the de-facto Unix editor &apos;Vi&apos;, with a more complete feature set. Vim is a highly configurable text editor built to enable efficient text editing. It is an improved version of the vi editor distributed with most UNIX systems.
+
+Security Fix(es):
+
+Use of Out-of-range Pointer Offset in GitHub repository vim/vim prior to 8.2.4418.(CVE-2022-0685)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">vim</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1580</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-0685</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2022-0685</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">openEuler-20.03-LTS-SP2</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-common-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-debugsource-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-enhanced-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-X11-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-minimal-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-debuginfo-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-enhanced-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-debuginfo-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-common-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-X11-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-debugsource-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-minimal-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-debugsource-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-minimal-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-debuginfo-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-X11-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-common-8.2-22.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-enhanced-8.2-22.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="vim-filesystem-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-filesystem-8.2-22.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="vim-filesystem-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-filesystem-8.2-22.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="vim-filesystem-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-filesystem-8.2-22.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="vim-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-8.2-22.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="vim-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-8.2-22.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="vim-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-8.2-22.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-minimal-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-X11-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-debuginfo-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-enhanced-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-debugsource-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">vim-common-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-enhanced-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-X11-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-minimal-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-common-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-debuginfo-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP2">vim-debugsource-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-enhanced-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-enhanced-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debuginfo-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-debuginfo-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-common-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-common-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-minimal-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-minimal-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-X11-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-X11-8.2-22.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="vim-debugsource-8.2-22" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">vim-debugsource-8.2-22.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">Use of Out-of-range Pointer Offset in GitHub repository vim/vim prior to 8.2.4418.</Note>
+		</Notes>
+		<ReleaseDate>2022-03-19</ReleaseDate>
+		<CVE>CVE-2022-0685</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP2</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.8</BaseScore>
+				<Vector>AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>vim security update</Description>
+				<DATE>2022-03-19</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1580</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2022-1693.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2022-1693.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1"
+><DocumentTitle xml:lang="en"
+>An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3</DocumentTitle
+><DocumentType
+>Security Advisory</DocumentType
+><DocumentPublisher Type="Vendor"
+><ContactDetails
+>openeuler-security@openeuler.org</ContactDetails
+><IssuingAuthority
+>openEuler security committee</IssuingAuthority
+></DocumentPublisher
+><DocumentTracking
+><Identification
+><ID
+>openEuler-SA-2022-1693</ID
+></Identification
+><Status
+>Final</Status
+><Version
+>1.0</Version
+><RevisionHistory
+><Revision
+><Number
+>1.0</Number
+><Date
+>2022-06-02</Date
+><Description
+>Initial</Description
+></Revision
+></RevisionHistory
+><InitialReleaseDate
+>2022-06-02</InitialReleaseDate
+><CurrentReleaseDate
+>2022-06-02</CurrentReleaseDate
+><Generator
+><Engine
+>openEuler SA Tool V1.0</Engine
+><Date
+>2022-06-02</Date
+></Generator
+></DocumentTracking
+><DocumentNotes
+><Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en"
+>python-XStatic-jquery-ui security update</Note
+><Note Title="Summary" Type="General" Ordinal="2" xml:lang="en"
+>An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3.</Note
+><Note Title="Description" Type="General" Ordinal="3" xml:lang="en"
+>jquery-ui javascript library packaged for setuptools (easy_install) / pip. This package is intended to be used by **any** project that needs these files. It intentionally does **not** provide any extra code except some metadata **nor** has any extra requirements. You MAY use some minimal support code from the XStatic base package, if you like. You can find more info about the xstatic packaging way in the package `XStatic`.
+
+Security Fix(es):
+
+jQuery-UI is the official jQuery user interface library. Prior to version 1.13.0, accepting the value of various `*Text` options of the Datepicker widget from untrusted sources may execute untrusted code. The issue is fixed in jQuery UI 1.13.0. The values passed to various `*Text` options are now always treated as pure text, not HTML. A workaround is to not accept the value of the `*Text` options from untrusted sources.(CVE-2021-41183)</Note>
+<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en"
+>An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en"
+>Medium</Note
+><Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">python-XStatic-jquery-ui</Note>
+</DocumentNotes
+><DocumentReferences
+><Reference Type="Self"
+><URL
+>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1693</URL
+></Reference
+><Reference Type="openEuler CVE"
+><URL
+>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-41183</URL
+></Reference>
+<Reference Type="Other"
+><URL
+>https://nvd.nist.gov/vuln/detail/CVE-2021-41183</URL
+></Reference
+></DocumentReferences>
+<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1"
+><Branch Type="Product Name" Name="openEuler"
+><FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName
+></Branch
+><Branch Type="Package Arch" Name="noarch"
+><FullProductName ProductID="python3-XStatic-jquery-ui-1.12.1.1-2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3"
+>python3-XStatic-jquery-ui-1.12.1.1-2.oe1.noarch.rpm</FullProductName
+><FullProductName ProductID="python-XStatic-jquery-ui-help-1.12.1.1-2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python-XStatic-jquery-ui-help-1.12.1.1-2.oe1.noarch.rpm</FullProductName
+></Branch
+><Branch Type="Package Arch" Name="src"
+><FullProductName ProductID="python-XStatic-jquery-ui-1.12.1.1-2" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python-XStatic-jquery-ui-1.12.1.1-2.oe1.src.rpm</FullProductName
+></Branch
+></ProductTree
+><Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1"
+><Notes
+><Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">jQuery-UI is the official jQuery user interface library. Prior to version 1.13.0, accepting the value of various `*Text` options of the Datepicker widget from untrusted sources may execute untrusted code. The issue is fixed in jQuery UI 1.13.0. The values passed to various `*Text` options are now always treated as pure text, not HTML. A workaround is to not accept the value of the `*Text` options from untrusted sources.</Note
+></Notes><ReleaseDate
+>2022-06-02</ReleaseDate
+><CVE>CVE-2021-41183</CVE
+><ProductStatuses
+><Status Type="Fixed"
+><ProductID
+>openEuler-20.03-LTS-SP3</ProductID
+></Status
+></ProductStatuses
+><Threats
+><Threat Type="Impact"
+><Description
+>Medium</Description
+></Threat
+></Threats
+><CVSSScoreSets
+><ScoreSet
+><BaseScore>6.1</BaseScore
+><Vector
+>AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N</Vector
+></ScoreSet
+></CVSSScoreSets
+><Remediations
+><Remediation Type="Vendor Fix"
+><Description
+>python-XStatic-jquery-ui security update</Description
+><DATE
+>2022-06-02</DATE
+><URL
+>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1693</URL
+></Remediation
+></Remediations
+></Vulnerability
+></cvrfdoc
+>

--- a/openeuler/testdata/cvrf-openEuler-SA-2022-1704.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2022-1704.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2022-1704</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2022-06-10</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2022-06-10</InitialReleaseDate>
+		<CurrentReleaseDate>2022-06-10</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2022-06-10</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">runc security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">runc is a CLI tool for spawning and running containers according to the OCI specification.
+
+Security Fix(es):
+
+runc is a CLI tool for spawning and running containers on Linux according to the OCI specification. A bug was found in runc prior to version 1.1.2 where `runc exec --cap` created processes with non-empty inheritable Linux process capabilities, creating an atypical Linux environment and enabling programs with inheritable file capabilities to elevate those capabilities to the permitted set during execve(2). This bug did not affect the container security sandbox as the inheritable set never contained more capabilities than were included in the container&apos;s bounding set. This bug has been fixed in runc 1.1.2. This fix changes `runc exec --cap` behavior such that the additional capabilities granted to the process being executed (as specified via `--cap` arguments) do not include inheritable capabilities. In addition, `runc spec` is changed to not set any inheritable capabilities in the created example OCI spec (`config.json`) file.(CVE-2022-29162)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">runc</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1704</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-29162</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2022-29162</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">openEuler-22.03-LTS</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-203" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">docker-runc-1.0.0.rc3-203.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-204" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">docker-runc-1.0.0.rc3-204.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-301" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">docker-runc-1.0.0.rc3-301.oe2203.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-203" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">docker-runc-1.0.0.rc3-203.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-204" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">docker-runc-1.0.0.rc3-204.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-301" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">docker-runc-1.0.0.rc3-301.oe2203.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-203" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">docker-runc-1.0.0.rc3-203.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-204" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">docker-runc-1.0.0.rc3-204.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="docker-runc-1.0.0.rc3-301" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">docker-runc-1.0.0.rc3-301.oe2203.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">runc is a CLI tool for spawning and running containers on Linux according to the OCI specification. A bug was found in runc prior to version 1.1.2 where `runc exec --cap` created processes with non-empty inheritable Linux process capabilities, creating an atypical Linux environment and enabling programs with inheritable file capabilities to elevate those capabilities to the permitted set during execve(2). This bug did not affect the container security sandbox as the inheritable set never contained more capabilities than were included in the container s bounding set. This bug has been fixed in runc 1.1.2. This fix changes `runc exec --cap` behavior such that the additional capabilities granted to the process being executed (as specified via `--cap` arguments) do not include inheritable capabilities. In addition, `runc spec` is changed to not set any inheritable capabilities in the created example OCI spec (`config.json`) file.</Note>
+		</Notes>
+		<ReleaseDate>2022-06-10</ReleaseDate>
+		<CVE>CVE-2022-29162</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+				<ProductID>openEuler-22.03-LTS</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>runc security update</Description>
+				<DATE>2022-06-10</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1704</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2023-1006.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2023-1006.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for curl is now available for openEuler-20.03-LTS-SP3</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2023-1006</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2023-01-06</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2023-01-06</InitialReleaseDate>
+		<CurrentReleaseDate>2023-01-06</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2023-01-06</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">curl security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for curl is now available for openEuler-20.03-LTS-SP3.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">cURL is a computer software project providing a library (libcurl) and command-line tool (curl) for transferring data using various protocols.
+
+Security Fix(es):
+
+A vulnerability was found in curl. In this issue, curl can be asked to tunnel all protocols virtually it supports through an HTTP proxy. HTTP proxies can deny these tunnel operations using an appropriate HTTP error response code. When getting denied to tunnel the specific SMB or TELNET protocols, curl can use a heap-allocated struct after it has been freed and shut down the code path in its transfer.(CVE-2022-43552)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for curl is now available for openEuler-20.03-LTS-SP3.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">curl</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1006</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-43552</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2022-43552</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="curl-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-7.71.1-20.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="curl-debuginfo-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-debuginfo-7.71.1-20.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libcurl-devel-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">libcurl-devel-7.71.1-20.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="libcurl-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">libcurl-7.71.1-20.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="curl-debugsource-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-debugsource-7.71.1-20.oe1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="curl-help-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-help-7.71.1-20.oe1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="curl-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-7.71.1-20.oe1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="libcurl-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">libcurl-7.71.1-20.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="curl-debuginfo-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-debuginfo-7.71.1-20.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="libcurl-devel-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">libcurl-devel-7.71.1-20.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="curl-debugsource-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-debugsource-7.71.1-20.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="curl-7.71.1-20" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">curl-7.71.1-20.oe1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">A vulnerability was found in curl. In this issue, curl can be asked to tunnel all protocols virtually it supports through an HTTP proxy. HTTP proxies can deny these tunnel operations using an appropriate HTTP error response code. When getting denied to tunnel the specific SMB or TELNET protocols, curl can use a heap-allocated struct after it has been freed and shut down the code path in its transfer.</Note>
+		</Notes>
+		<ReleaseDate>2023-01-06</ReleaseDate>
+		<CVE>CVE-2022-43552</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>curl security update</Description>
+				<DATE>2023-01-06</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1006</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2023-1010.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2023-1010.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2023-1010</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2023-01-06</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2023-01-06</InitialReleaseDate>
+		<CurrentReleaseDate>2023-01-06</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2023-01-06</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">net-snmp security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">Net-SNMP is a suite of applications used to implement SNMP v1, SNMP v2c and SNMP v3 using both IPv4 and IPv6. The suite includes:
+
+		- An extensible agent for responding to SNMP queries including built-in support for a wide range of MIB information modules
+		- Command-line applications to retrieve and manipulate information from SNMP-capable devices
+		- A daemon application for receiving SNMP notifications
+		- A library for developing new SNMP applications, with C and Perl APIs
+		- A graphical MIB browser.
+
+Security Fix(es):
+
+handle_ipv6IpForwarding in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.4.3 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.(CVE-2022-44793)
+
+handle_ipDefaultTTL in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.8 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker (who has write access) to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.(CVE-2022-44792)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">net-snmp</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1010</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-44793</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-44792</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2022-44793</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2022-44792</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">openEuler-20.03-LTS-SP3</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">openEuler-22.03-LTS</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">openEuler-22.03-LTS-SP1</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="python3-net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-net-snmp-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-gui-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-libs-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-perl-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-debugsource-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-debuginfo-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-devel-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-debugsource-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-gui-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-debuginfo-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-devel-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-net-snmp-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-libs-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-perl-5.9-8.oe1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-gui-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-debugsource-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-devel-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-libs-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-debuginfo-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-perl-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">python3-net-snmp-5.9.1-5.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-debugsource-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">python3-net-snmp-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-gui-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-debuginfo-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-perl-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-devel-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-libs-5.9.1-5.oe2203sp1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="noarch">
+			<FullProductName ProductID="net-snmp-help-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-help-5.9-8.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-help-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-help-5.9-8.oe1.noarch.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-help-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-help-5.9.1-5.oe2203.noarch.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-help-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-help-5.9.1-5.oe2203sp1.noarch.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-5.9-8.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-5.9-8.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-5.9.1-5.oe2203.src.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-5.9.1-5.oe2203sp1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="net-snmp-libs-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-libs-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-gui-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-debuginfo-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-perl-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">python3-net-snmp-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-devel-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">net-snmp-debugsource-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">python3-net-snmp-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-gui-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-libs-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-debuginfo-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-perl-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-debugsource-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9-8" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP3">net-snmp-devel-5.9-8.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-perl-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-gui-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-libs-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-devel-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-debuginfo-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">python3-net-snmp-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">net-snmp-debugsource-5.9.1-5.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debuginfo-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-debuginfo-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-perl-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-perl-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-devel-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-devel-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-debugsource-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-debugsource-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">python3-net-snmp-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-libs-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-libs-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-gui-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-gui-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="net-snmp-5.9.1-5" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">net-snmp-5.9.1-5.oe2203sp1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">handle_ipv6IpForwarding in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.4.3 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.</Note>
+		</Notes>
+		<ReleaseDate>2023-01-06</ReleaseDate>
+		<CVE>CVE-2022-44793</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+				<ProductID>openEuler-22.03-LTS</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>6.5</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>net-snmp security update</Description>
+				<DATE>2023-01-06</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1010</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">handle_ipDefaultTTL in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.8 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker (who has write access) to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.</Note>
+		</Notes>
+		<ReleaseDate>2023-01-06</ReleaseDate>
+		<CVE>CVE-2022-44792</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP3</ProductID>
+				<ProductID>openEuler-22.03-LTS</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>6.5</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>net-snmp security update</Description>
+				<DATE>2023-01-06</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1010</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2023-1374.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2023-1374.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for wireshark is now available for openEuler-22.03-LTS-SP1</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2023-1374</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2023-06-27</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2023-06-27</InitialReleaseDate>
+		<CurrentReleaseDate>2023-06-27</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2023-06-27</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">wireshark security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for wireshark is now available for openEuler-22.03-LTS-SP1.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">Wireshark allows you to examine protocol data stored in files or as it is captured from wired or wireless (WiFi or Bluetooth) networks, USB devices, and many other sources.  It supports dozens of protocol capture file formats and understands more than a thousand protocols. It has many powerful features including a rich display filter language and the ability to reassemble multiple protocol packets in order to, for example, view a complete TCP stream, save the contents of a file which was transferred over HTTP or CIFS, or play back an RTP audio stream.
+
+Security Fix(es):
+
+XRA dissector infinite loop in Wireshark 4.0.0 to 4.0.5 and 3.6.0 to 3.6.13 allows denial of service via packet injection or crafted capture file(CVE-2023-2952)
+
+Due to failure in validating the length provided by an attacker-crafted MSMMS packet, Wireshark version 4.0.5 and prior, in an unusual configuration, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark(CVE-2023-0667)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for wireshark is now available for openEuler-22.03-LTS-SP1.
+
+openEuler Security has rated this update as having a security impact of critical. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Critical</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">wireshark</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1374</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-2952</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-0667</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-2952</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-0667</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-22.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">openEuler-22.03-LTS-SP1</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="wireshark-devel-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-devel-3.6.14-1.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-debugsource-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-debugsource-3.6.14-1.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-help-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-help-3.6.14-1.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-debuginfo-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-debuginfo-3.6.14-1.oe2203sp1.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-3.6.14-1.oe2203sp1.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="wireshark-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-3.6.14-1.oe2203sp1.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="wireshark-debugsource-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-debugsource-3.6.14-1.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-help-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-help-3.6.14-1.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-devel-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-devel-3.6.14-1.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-debuginfo-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-debuginfo-3.6.14-1.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="wireshark-3.6.14-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">wireshark-3.6.14-1.oe2203sp1.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">XRA dissector infinite loop in Wireshark 4.0.0 to 4.0.5 and 3.6.0 to 3.6.13 allows denial of service via packet injection or crafted capture file</Note>
+		</Notes>
+		<ReleaseDate>2023-06-27</ReleaseDate>
+		<CVE>CVE-2023-2952</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>6.5</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>wireshark security update</Description>
+				<DATE>2023-06-27</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1374</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">Due to failure in validating the length provided by an attacker-crafted MSMMS packet, Wireshark version 4.0.5 and prior, in an unusual configuration, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark</Note>
+		</Notes>
+		<ReleaseDate>2023-06-27</ReleaseDate>
+		<CVE>CVE-2023-0667</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Critical</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>9.8</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>wireshark security update</Description>
+				<DATE>2023-06-27</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1374</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2024-1151.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2024-1151.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for openjdk-11 is now available for openEuler-22.03-LTS</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2024-1151</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2024-02-08</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2024-02-08</InitialReleaseDate>
+		<CurrentReleaseDate>2024-02-08</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2024-02-08</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">openjdk-11 security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for openjdk-11 is now available for openEuler-22.03-LTS.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">The OpenJDK runtime environment.
+
+Security Fix(es):
+
+Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service.(CVE-2024-20919)
+
+Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security.(CVE-2024-20921)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for openjdk-11 is now available for openEuler-22.03-LTS.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">openjdk-11</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1151</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2024-20919</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2024-20921</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2024-20919</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2024-20921</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-22.03-LTS" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">openEuler-22.03-LTS</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="java-11-openjdk-devel-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-devel-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-devel-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-devel-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-jmods-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-jmods-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-javadoc-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-javadoc-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-demo-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-demo-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-jmods-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-jmods-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-src-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-src-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-debuginfo-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-debuginfo-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-debugsource-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-debugsource-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-headless-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-headless-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-src-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-src-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-headless-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-headless-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-javadoc-zip-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-javadoc-zip-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-demo-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-demo-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="java-11-openjdk-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-11.0.22.7-0.oe2203.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="java-11-openjdk-javadoc-zip-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-javadoc-zip-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-demo-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-demo-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-devel-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-devel-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-headless-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-headless-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-jmods-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-jmods-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-src-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-src-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-jmods-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-jmods-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-debuginfo-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-debuginfo-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-demo-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-demo-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-javadoc-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-javadoc-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-debugsource-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-debugsource-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-headless-slowdebug-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-headless-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-src-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-src-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="java-11-openjdk-devel-11.0.22.7-0" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">java-11-openjdk-devel-11.0.22.7-0.oe2203.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service.</Note>
+		</Notes>
+		<ReleaseDate>2024-02-08</ReleaseDate>
+		<CVE>CVE-2024-20919</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>openjdk-11 security update</Description>
+				<DATE>2024-02-08</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1151</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security.</Note>
+		</Notes>
+		<ReleaseDate>2024-02-08</ReleaseDate>
+		<CVE>CVE-2024-20921</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.9</BaseScore>
+				<Vector>AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>openjdk-11 security update</Description>
+				<DATE>2024-02-08</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1151</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2024-1295.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2024-1295.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2024-1295</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2024-03-22</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2024-03-22</InitialReleaseDate>
+		<CurrentReleaseDate>2024-03-22</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2024-03-22</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">microcode_ctl security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">This is a tool to transform and deploy microcode update for x86 CPUs.
+
+Security Fix(es):
+
+Non-transparent sharing of return predictor targets between contexts in some Intel(R) Processors may allow an authorized user to potentially enable information disclosure via local access.(CVE-2023-38575)
+
+Protection mechanism failure of bus lock regulator for some Intel(R) Processors may allow an unauthenticated user to potentially enable denial of service via network access.(CVE-2023-39368)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3.
+
+openEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">Medium</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">microcode_ctl</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1295</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-38575</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-39368</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-38575</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-39368</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-20.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">openEuler-20.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-20.03-LTS-SP4" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP4">openEuler-20.03-LTS-SP4</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">openEuler-22.03-LTS</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS-SP1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">openEuler-22.03-LTS-SP1</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS-SP2" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">openEuler-22.03-LTS-SP2</FullProductName>
+			<FullProductName ProductID="openEuler-22.03-LTS-SP3" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP3">openEuler-22.03-LTS-SP3</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">microcode_ctl-20240312-1.oe1.src.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP4">microcode_ctl-20240312-1.oe2003sp4.src.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">microcode_ctl-20240312-1.oe2203.src.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">microcode_ctl-20240312-1.oe2203sp1.src.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">microcode_ctl-20240312-1.oe2203sp2.src.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP3">microcode_ctl-20240312-1.oe2203sp3.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP1">microcode_ctl-20240312-1.oe1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:20.03-LTS-SP4">microcode_ctl-20240312-1.oe2003sp4.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS">microcode_ctl-20240312-1.oe2203.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP1">microcode_ctl-20240312-1.oe2203sp1.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">microcode_ctl-20240312-1.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="microcode_ctl-20240312-1" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP3">microcode_ctl-20240312-1.oe2203sp3.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">Non-transparent sharing of return predictor targets between contexts in some Intel(R) Processors may allow an authorized user to potentially enable information disclosure via local access.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-22</ReleaseDate>
+		<CVE>CVE-2023-38575</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP4</ProductID>
+				<ProductID>openEuler-22.03-LTS</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP3</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.5</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>microcode_ctl security update</Description>
+				<DATE>2024-03-22</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1295</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">Protection mechanism failure of bus lock regulator for some Intel(R) Processors may allow an unauthenticated user to potentially enable denial of service via network access.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-22</ReleaseDate>
+		<CVE>CVE-2023-39368</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-20.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-20.03-LTS-SP4</ProductID>
+				<ProductID>openEuler-22.03-LTS</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP1</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+				<ProductID>openEuler-22.03-LTS-SP3</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>6.5</BaseScore>
+				<Vector>AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>microcode_ctl security update</Description>
+				<DATE>2024-03-22</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1295</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/cvrf-openEuler-SA-2024-1349.xml
+++ b/openeuler/testdata/cvrf-openEuler-SA-2024-1349.xml
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1">
+	<DocumentTitle xml:lang="en">An update for kernel is now available for openEuler-22.03-LTS-SP2</DocumentTitle>
+	<DocumentType>Security Advisory</DocumentType>
+	<DocumentPublisher Type="Vendor">
+		<ContactDetails>openeuler-security@openeuler.org</ContactDetails>
+		<IssuingAuthority>openEuler security committee</IssuingAuthority>
+	</DocumentPublisher>
+	<DocumentTracking>
+		<Identification>
+			<ID>openEuler-SA-2024-1349</ID>
+		</Identification>
+		<Status>Final</Status>
+		<Version>1.0</Version>
+		<RevisionHistory>
+			<Revision>
+				<Number>1.0</Number>
+				<Date>2024-03-29</Date>
+				<Description>Initial</Description>
+			</Revision>
+		</RevisionHistory>
+		<InitialReleaseDate>2024-03-29</InitialReleaseDate>
+		<CurrentReleaseDate>2024-03-29</CurrentReleaseDate>
+		<Generator>
+			<Engine>openEuler SA Tool V1.0</Engine>
+			<Date>2024-03-29</Date>
+		</Generator>
+	</DocumentTracking>
+	<DocumentNotes>
+		<Note Title="Synopsis" Type="General" Ordinal="1" xml:lang="en">kernel security update</Note>
+		<Note Title="Summary" Type="General" Ordinal="2" xml:lang="en">An update for kernel is now available for openEuler-22.03-LTS-SP2.</Note>
+		<Note Title="Description" Type="General" Ordinal="3" xml:lang="en">The Linux Kernel, the operating system core itself.
+
+Security Fix(es):
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+net/sched: act_ct: fix wild memory access when clearing fragments
+
+while testing re-assembly/re-fragmentation using act_ct, it&apos;s possible to
+observe a crash like the following one:
+
+ KASAN: maybe wild-memory-access in range [0x0001000000000448-0x000100000000044f]
+ CPU: 50 PID: 0 Comm: swapper/50 Tainted: G S                5.12.0-rc7+ #424
+ Hardware name: Dell Inc. PowerEdge R730/072T6D, BIOS 2.4.3 01/17/2017
+ RIP: 0010:inet_frag_rbtree_purge+0x50/0xc0
+ Code: 00 fc ff df 48 89 c3 31 ed 48 89 df e8 a9 7a 38 ff 4c 89 fe 48 89 df 49 89 c6 e8 5b 3a 38 ff 48 8d 7b 40 48 89 f8 48 c1 e8 03 &lt;42&gt; 80 3c 20 00 75 59 48 8d bb d0 00 00 00 4c 8b 6b 40 48 89 f8 48
+ RSP: 0018:ffff888c31449db8 EFLAGS: 00010203
+ RAX: 0000200000000089 RBX: 000100000000040e RCX: ffffffff989eb960
+ RDX: 0000000000000140 RSI: ffffffff97cfb977 RDI: 000100000000044e
+ RBP: 0000000000000900 R08: 0000000000000000 R09: ffffed1186289350
+ R10: 0000000000000003 R11: ffffed1186289350 R12: dffffc0000000000
+ R13: 000100000000040e R14: 0000000000000000 R15: ffff888155e02160
+ FS:  0000000000000000(0000) GS:ffff888c31440000(0000) knlGS:0000000000000000
+ CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+ CR2: 00005600cb70a5b8 CR3: 0000000a2c014005 CR4: 00000000003706e0
+ DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+ DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+ Call Trace:
+  &lt;IRQ&gt;
+  inet_frag_destroy+0xa9/0x150
+  call_timer_fn+0x2d/0x180
+  run_timer_softirq+0x4fe/0xe70
+  __do_softirq+0x197/0x5a0
+  irq_exit_rcu+0x1de/0x200
+  sysvec_apic_timer_interrupt+0x6b/0x80
+  &lt;/IRQ&gt;
+
+when act_ct temporarily stores an IP fragment, restoring the skb qdisc cb
+results in putting random data in FRAG_CB(), and this causes those &quot;wild&quot;
+memory accesses later, when the rbtree is purged. Never overwrite the skb
+cb in case tcf_ct_handle_fragments() returns -EINPROGRESS.(CVE-2021-47014)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+udp: skip L4 aggregation for UDP tunnel packets
+
+If NETIF_F_GRO_FRAGLIST or NETIF_F_GRO_UDP_FWD are enabled, and there
+are UDP tunnels available in the system, udp_gro_receive() could end-up
+doing L4 aggregation (either SKB_GSO_UDP_L4 or SKB_GSO_FRAGLIST) at
+the outer UDP tunnel level for packets effectively carrying and UDP
+tunnel header.
+
+That could cause inner protocol corruption. If e.g. the relevant
+packets carry a vxlan header, different vxlan ids will be ignored/
+aggregated to the same GSO packet. Inner headers will be ignored, too,
+so that e.g. TCP over vxlan push packets will be held in the GRO
+engine till the next flush, etc.
+
+Just skip the SKB_GSO_UDP_L4 and SKB_GSO_FRAGLIST code path if the
+current packet could land in a UDP tunnel, and let udp_gro_receive()
+do GRO via udp_sk(sk)-&gt;gro_receive.
+
+The check implemented in this patch is broader than what is strictly
+needed, as the existing UDP tunnel could be e.g. configured on top of
+a different device: we could end-up skipping GRO at-all for some packets.
+
+Anyhow, that is a very thin corner case and covering it will add quite
+a bit of complexity.
+
+v1 -&gt; v2:
+ - hopefully clarify the commit message(CVE-2021-47036)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+media: pvrusb2: fix use after free on context disconnection
+
+Upon module load, a kthread is created targeting the
+pvr2_context_thread_func function, which may call pvr2_context_destroy
+and thus call kfree() on the context object. However, that might happen
+before the usb hub_event handler is able to notify the driver. This
+patch adds a sanity check before the invalid read reported by syzbot,
+within the context disconnection call stack.(CVE-2023-52445)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+block: add check that partition length needs to be aligned with block size
+
+Before calling add partition or resize partition, there is no check
+on whether the length is aligned with the logical block size.
+If the logical block size of the disk is larger than 512 bytes,
+then the partition size maybe not the multiple of the logical block size,
+and when the last sector is read, bio_truncate() will adjust the bio size,
+resulting in an IO error if the size of the read command is smaller than
+the logical block size.If integrity data is supported, this will also
+result in a null pointer dereference when calling bio_integrity_free.(CVE-2023-52458)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+net: usb: smsc75xx: Fix uninit-value access in __smsc75xx_read_reg
+
+syzbot reported the following uninit-value access issue:
+
+=====================================================
+BUG: KMSAN: uninit-value in smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]
+BUG: KMSAN: uninit-value in smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482
+CPU: 0 PID: 8696 Comm: kworker/0:3 Not tainted 5.8.0-rc5-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Workqueue: usb_hub_wq hub_event
+Call Trace:
+ __dump_stack lib/dump_stack.c:77 [inline]
+ dump_stack+0x21c/0x280 lib/dump_stack.c:118
+ kmsan_report+0xf7/0x1e0 mm/kmsan/kmsan_report.c:121
+ __msan_warning+0x58/0xa0 mm/kmsan/kmsan_instr.c:215
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]
+ smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482
+ usbnet_probe+0x1152/0x3f90 drivers/net/usb/usbnet.c:1737
+ usb_probe_interface+0xece/0x1550 drivers/usb/core/driver.c:374
+ really_probe+0xf20/0x20b0 drivers/base/dd.c:529
+ driver_probe_device+0x293/0x390 drivers/base/dd.c:701
+ __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807
+ bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431
+ __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873
+ device_initial_probe+0x4a/0x60 drivers/base/dd.c:920
+ bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491
+ device_add+0x3b0e/0x40d0 drivers/base/core.c:2680
+ usb_set_configuration+0x380f/0x3f10 drivers/usb/core/message.c:2032
+ usb_generic_driver_probe+0x138/0x300 drivers/usb/core/generic.c:241
+ usb_probe_device+0x311/0x490 drivers/usb/core/driver.c:272
+ really_probe+0xf20/0x20b0 drivers/base/dd.c:529
+ driver_probe_device+0x293/0x390 drivers/base/dd.c:701
+ __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807
+ bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431
+ __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873
+ device_initial_probe+0x4a/0x60 drivers/base/dd.c:920
+ bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491
+ device_add+0x3b0e/0x40d0 drivers/base/core.c:2680
+ usb_new_device+0x1bd4/0x2a30 drivers/usb/core/hub.c:2554
+ hub_port_connect drivers/usb/core/hub.c:5208 [inline]
+ hub_port_connect_change drivers/usb/core/hub.c:5348 [inline]
+ port_event drivers/usb/core/hub.c:5494 [inline]
+ hub_event+0x5e7b/0x8a70 drivers/usb/core/hub.c:5576
+ process_one_work+0x1688/0x2140 kernel/workqueue.c:2269
+ worker_thread+0x10bc/0x2730 kernel/workqueue.c:2415
+ kthread+0x551/0x590 kernel/kthread.c:292
+ ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:293
+
+Local variable ----buf.i87@smsc75xx_bind created at:
+ __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]
+ smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482
+ __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]
+ smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482
+
+This issue is caused because usbnet_read_cmd() reads less bytes than requested
+(zero byte in the reproducer). In this case, &apos;buf&apos; is not properly filled.
+
+This patch fixes the issue by returning -ENODATA if usbnet_read_cmd() reads
+less bytes than requested.(CVE-2023-52528)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+wifi: wfx: fix possible NULL pointer dereference in wfx_set_mfp_ap()
+
+Since &apos;ieee80211_beacon_get()&apos; can return NULL, &apos;wfx_set_mfp_ap()&apos;
+should check the return value before examining skb data. So convert
+the latter to return an appropriate error code and propagate it to
+return from &apos;wfx_start_ap()&apos; as well. Compile tested only.(CVE-2023-52593)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+jfs: fix slab-out-of-bounds Read in dtSearch
+
+Currently while searching for current page in the sorted entry table
+of the page there is a out of bound access. Added a bound check to fix
+the error.
+
+Dave:
+Set return code to -EIO(CVE-2023-52602)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+UBSAN: array-index-out-of-bounds in dtSplitRoot
+
+Syzkaller reported the following issue:
+
+oop0: detected capacity change from 0 to 32768
+
+UBSAN: array-index-out-of-bounds in fs/jfs/jfs_dtree.c:1971:9
+index -2 is out of range for type &apos;struct dtslot [128]&apos;
+CPU: 0 PID: 3613 Comm: syz-executor270 Not tainted 6.0.0-syzkaller-09423-g493ffd6605b2 #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1b1/0x28e lib/dump_stack.c:106
+ ubsan_epilogue lib/ubsan.c:151 [inline]
+ __ubsan_handle_out_of_bounds+0xdb/0x130 lib/ubsan.c:283
+ dtSplitRoot+0x8d8/0x1900 fs/jfs/jfs_dtree.c:1971
+ dtSplitUp fs/jfs/jfs_dtree.c:985 [inline]
+ dtInsert+0x1189/0x6b80 fs/jfs/jfs_dtree.c:863
+ jfs_mkdir+0x757/0xb00 fs/jfs/namei.c:270
+ vfs_mkdir+0x3b3/0x590 fs/namei.c:4013
+ do_mkdirat+0x279/0x550 fs/namei.c:4038
+ __do_sys_mkdirat fs/namei.c:4053 [inline]
+ __se_sys_mkdirat fs/namei.c:4051 [inline]
+ __x64_sys_mkdirat+0x85/0x90 fs/namei.c:4051
+ do_syscall_x64 arch/x86/entry/common.c:50 [inline]
+ do_syscall_64+0x3d/0xb0 arch/x86/entry/common.c:80
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7fcdc0113fd9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 &lt;48&gt; 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007ffeb8bc67d8 EFLAGS: 00000246 ORIG_RAX: 0000000000000102
+RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007fcdc0113fd9
+RDX: 0000000000000000 RSI: 0000000020000340 RDI: 0000000000000003
+RBP: 00007fcdc00d37a0 R08: 0000000000000000 R09: 00007fcdc00d37a0
+R10: 00005555559a72c0 R11: 0000000000000246 R12: 00000000f8008000
+R13: 0000000000000000 R14: 00083878000000f8 R15: 0000000000000000
+ &lt;/TASK&gt;
+
+The issue is caused when the value of fsi becomes less than -1.
+The check to break the loop when fsi value becomes -1 is present
+but syzbot was able to produce value less than -1 which cause the error.
+This patch simply add the change for the values less than 0.
+
+The patch is tested via syzbot.(CVE-2023-52603)
+
+In the Linux kernel, the following vulnerability has been resolved:
+
+FS:JFS:UBSAN:array-index-out-of-bounds in dbAdjTree
+
+Syzkaller reported the following issue:
+
+UBSAN: array-index-out-of-bounds in fs/jfs/jfs_dmap.c:2867:6
+index 196694 is out of range for type &apos;s8[1365]&apos; (aka &apos;signed char[1365]&apos;)
+CPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106
+ ubsan_epilogue lib/ubsan.c:217 [inline]
+ __ubsan_handle_out_of_bounds+0x11c/0x150 lib/ubsan.c:348
+ dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867
+ dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834
+ dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331
+ dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]
+ dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402
+ txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534
+ txUpdateMap+0x342/0x9e0
+ txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]
+ jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732
+ kthread+0x2d3/0x370 kernel/kthread.c:388
+ ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147
+ ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304
+ &lt;/TASK&gt;
+================================================================================
+Kernel panic - not syncing: UBSAN: panic_on_warn set ...
+CPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106
+ panic+0x30f/0x770 kernel/panic.c:340
+ check_panic_on_warn+0x82/0xa0 kernel/panic.c:236
+ ubsan_epilogue lib/ubsan.c:223 [inline]
+ __ubsan_handle_out_of_bounds+0x13c/0x150 lib/ubsan.c:348
+ dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867
+ dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834
+ dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331
+ dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]
+ dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402
+ txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534
+ txUpdateMap+0x342/0x9e0
+ txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]
+ jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732
+ kthread+0x2d3/0x370 kernel/kthread.c:388
+ ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147
+ ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304
+ &lt;/TASK&gt;
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+
+The issue is caused when the value of lp becomes greater than
+CTLTREESIZE which is the max size of stree. Adding a simple check
+solves this issue.
+
+Dave:
+As the function returns a void, good error handling
+would require a more intrusive code reorganization, so I modified
+Osama&apos;s patch at use WARN_ON_ONCE for lack of a cleaner option.
+
+The patch is tested via syzbot.(CVE-2023-52604)</Note>
+		<Note Title="Topic" Type="General" Ordinal="4" xml:lang="en">An update for kernel is now available for openEuler-22.03-LTS-SP2.
+
+openEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.</Note>
+		<Note Title="Severity" Type="General" Ordinal="5" xml:lang="en">High</Note>
+		<Note Title="Affected Component" Type="General" Ordinal="6" xml:lang="en">kernel</Note>
+	</DocumentNotes>
+	<DocumentReferences>
+		<Reference Type="Self">
+			<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+		</Reference>
+		<Reference Type="openEuler CVE">
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-47014</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-47036</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52445</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52458</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52528</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52593</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52602</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52603</URL>
+			<URL>https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52604</URL>
+		</Reference>
+		<Reference Type="Other">
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-47014</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2021-47036</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52445</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52458</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52528</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52593</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52602</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52603</URL>
+			<URL>https://nvd.nist.gov/vuln/detail/CVE-2023-52604</URL>
+		</Reference>
+	</DocumentReferences>
+	<ProductTree xmlns="http://www.icasi.org/CVRF/schema/prod/1.1">
+		<Branch Type="Product Name" Name="openEuler">
+			<FullProductName ProductID="openEuler-22.03-LTS-SP2" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">openEuler-22.03-LTS-SP2</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="aarch64">
+			<FullProductName ProductID="perf-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">perf-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="perf-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-tools-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-tools-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-headers-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-headers-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-perf-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">python3-perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-tools-devel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-devel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="python3-perf-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">python3-perf-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-debugsource-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-debugsource-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-source-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-source-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-devel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-devel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="src">
+			<FullProductName ProductID="kernel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-5.10.0-153.48.0.126.oe2203sp2.src.rpm</FullProductName>
+		</Branch>
+		<Branch Type="Package Arch" Name="x86_64">
+			<FullProductName ProductID="kernel-tools-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-debugsource-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-debugsource-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-perf-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">python3-perf-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-source-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-source-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="python3-perf-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">python3-perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-headers-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-headers-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-tools-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-tools-devel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-tools-devel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="perf-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">perf-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-devel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-devel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="kernel-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">kernel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+			<FullProductName ProductID="perf-debuginfo-5.10.0-153.48.0.126" CPE="cpe:/a:openEuler:openEuler:22.03-LTS-SP2">perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm</FullProductName>
+		</Branch>
+	</ProductTree>
+	<Vulnerability Ordinal="1" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+net/sched: act_ct: fix wild memory access when clearing fragments
+
+while testing re-assembly/re-fragmentation using act_ct, it&apos;s possible to
+observe a crash like the following one:
+
+ KASAN: maybe wild-memory-access in range [0x0001000000000448-0x000100000000044f]
+ CPU: 50 PID: 0 Comm: swapper/50 Tainted: G S                5.12.0-rc7+ #424
+ Hardware name: Dell Inc. PowerEdge R730/072T6D, BIOS 2.4.3 01/17/2017
+ RIP: 0010:inet_frag_rbtree_purge+0x50/0xc0
+ Code: 00 fc ff df 48 89 c3 31 ed 48 89 df e8 a9 7a 38 ff 4c 89 fe 48 89 df 49 89 c6 e8 5b 3a 38 ff 48 8d 7b 40 48 89 f8 48 c1 e8 03 &lt;42&gt; 80 3c 20 00 75 59 48 8d bb d0 00 00 00 4c 8b 6b 40 48 89 f8 48
+ RSP: 0018:ffff888c31449db8 EFLAGS: 00010203
+ RAX: 0000200000000089 RBX: 000100000000040e RCX: ffffffff989eb960
+ RDX: 0000000000000140 RSI: ffffffff97cfb977 RDI: 000100000000044e
+ RBP: 0000000000000900 R08: 0000000000000000 R09: ffffed1186289350
+ R10: 0000000000000003 R11: ffffed1186289350 R12: dffffc0000000000
+ R13: 000100000000040e R14: 0000000000000000 R15: ffff888155e02160
+ FS:  0000000000000000(0000) GS:ffff888c31440000(0000) knlGS:0000000000000000
+ CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+ CR2: 00005600cb70a5b8 CR3: 0000000a2c014005 CR4: 00000000003706e0
+ DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+ DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+ Call Trace:
+  &lt;IRQ&gt;
+  inet_frag_destroy+0xa9/0x150
+  call_timer_fn+0x2d/0x180
+  run_timer_softirq+0x4fe/0xe70
+  __do_softirq+0x197/0x5a0
+  irq_exit_rcu+0x1de/0x200
+  sysvec_apic_timer_interrupt+0x6b/0x80
+  &lt;/IRQ&gt;
+
+when act_ct temporarily stores an IP fragment, restoring the skb qdisc cb
+results in putting random data in FRAG_CB(), and this causes those &quot;wild&quot;
+memory accesses later, when the rbtree is purged. Never overwrite the skb
+cb in case tcf_ct_handle_fragments() returns -EINPROGRESS.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2021-47014</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.1</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="2" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="2" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+udp: skip L4 aggregation for UDP tunnel packets
+
+If NETIF_F_GRO_FRAGLIST or NETIF_F_GRO_UDP_FWD are enabled, and there
+are UDP tunnels available in the system, udp_gro_receive() could end-up
+doing L4 aggregation (either SKB_GSO_UDP_L4 or SKB_GSO_FRAGLIST) at
+the outer UDP tunnel level for packets effectively carrying and UDP
+tunnel header.
+
+That could cause inner protocol corruption. If e.g. the relevant
+packets carry a vxlan header, different vxlan ids will be ignored/
+aggregated to the same GSO packet. Inner headers will be ignored, too,
+so that e.g. TCP over vxlan push packets will be held in the GRO
+engine till the next flush, etc.
+
+Just skip the SKB_GSO_UDP_L4 and SKB_GSO_FRAGLIST code path if the
+current packet could land in a UDP tunnel, and let udp_gro_receive()
+do GRO via udp_sk(sk)-&gt;gro_receive.
+
+The check implemented in this patch is broader than what is strictly
+needed, as the existing UDP tunnel could be e.g. configured on top of
+a different device: we could end-up skipping GRO at-all for some packets.
+
+Anyhow, that is a very thin corner case and covering it will add quite
+a bit of complexity.
+
+v1 -&gt; v2:
+ - hopefully clarify the commit message</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2021-47036</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>5.3</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="3" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="3" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+media: pvrusb2: fix use after free on context disconnection
+
+Upon module load, a kthread is created targeting the
+pvr2_context_thread_func function, which may call pvr2_context_destroy
+and thus call kfree() on the context object. However, that might happen
+before the usb hub_event handler is able to notify the driver. This
+patch adds a sanity check before the invalid read reported by syzbot,
+within the context disconnection call stack.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52445</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.8</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="4" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="4" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+block: add check that partition length needs to be aligned with block size
+
+Before calling add partition or resize partition, there is no check
+on whether the length is aligned with the logical block size.
+If the logical block size of the disk is larger than 512 bytes,
+then the partition size maybe not the multiple of the logical block size,
+and when the last sector is read, bio_truncate() will adjust the bio size,
+resulting in an IO error if the size of the read command is smaller than
+the logical block size.If integrity data is supported, this will also
+result in a null pointer dereference when calling bio_integrity_free.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52458</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>4.2</BaseScore>
+				<Vector>AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="5" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="5" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+net: usb: smsc75xx: Fix uninit-value access in __smsc75xx_read_reg
+
+syzbot reported the following uninit-value access issue:
+
+=====================================================
+BUG: KMSAN: uninit-value in smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]
+BUG: KMSAN: uninit-value in smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482
+CPU: 0 PID: 8696 Comm: kworker/0:3 Not tainted 5.8.0-rc5-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Workqueue: usb_hub_wq hub_event
+Call Trace:
+ __dump_stack lib/dump_stack.c:77 [inline]
+ dump_stack+0x21c/0x280 lib/dump_stack.c:118
+ kmsan_report+0xf7/0x1e0 mm/kmsan/kmsan_report.c:121
+ __msan_warning+0x58/0xa0 mm/kmsan/kmsan_instr.c:215
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]
+ smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482
+ usbnet_probe+0x1152/0x3f90 drivers/net/usb/usbnet.c:1737
+ usb_probe_interface+0xece/0x1550 drivers/usb/core/driver.c:374
+ really_probe+0xf20/0x20b0 drivers/base/dd.c:529
+ driver_probe_device+0x293/0x390 drivers/base/dd.c:701
+ __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807
+ bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431
+ __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873
+ device_initial_probe+0x4a/0x60 drivers/base/dd.c:920
+ bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491
+ device_add+0x3b0e/0x40d0 drivers/base/core.c:2680
+ usb_set_configuration+0x380f/0x3f10 drivers/usb/core/message.c:2032
+ usb_generic_driver_probe+0x138/0x300 drivers/usb/core/generic.c:241
+ usb_probe_device+0x311/0x490 drivers/usb/core/driver.c:272
+ really_probe+0xf20/0x20b0 drivers/base/dd.c:529
+ driver_probe_device+0x293/0x390 drivers/base/dd.c:701
+ __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807
+ bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431
+ __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873
+ device_initial_probe+0x4a/0x60 drivers/base/dd.c:920
+ bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491
+ device_add+0x3b0e/0x40d0 drivers/base/core.c:2680
+ usb_new_device+0x1bd4/0x2a30 drivers/usb/core/hub.c:2554
+ hub_port_connect drivers/usb/core/hub.c:5208 [inline]
+ hub_port_connect_change drivers/usb/core/hub.c:5348 [inline]
+ port_event drivers/usb/core/hub.c:5494 [inline]
+ hub_event+0x5e7b/0x8a70 drivers/usb/core/hub.c:5576
+ process_one_work+0x1688/0x2140 kernel/workqueue.c:2269
+ worker_thread+0x10bc/0x2730 kernel/workqueue.c:2415
+ kthread+0x551/0x590 kernel/kthread.c:292
+ ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:293
+
+Local variable ----buf.i87@smsc75xx_bind created at:
+ __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]
+ smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482
+ __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]
+ smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]
+ smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482
+
+This issue is caused because usbnet_read_cmd() reads less bytes than requested
+(zero byte in the reproducer). In this case, &apos;buf&apos; is not properly filled.
+
+This patch fixes the issue by returning -ENODATA if usbnet_read_cmd() reads
+less bytes than requested.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52528</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>4.4</BaseScore>
+				<Vector>AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="6" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="6" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+wifi: wfx: fix possible NULL pointer dereference in wfx_set_mfp_ap()
+
+Since &apos;ieee80211_beacon_get()&apos; can return NULL, &apos;wfx_set_mfp_ap()&apos;
+should check the return value before examining skb data. So convert
+the latter to return an appropriate error code and propagate it to
+return from &apos;wfx_start_ap()&apos; as well. Compile tested only.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52593</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>Medium</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>4.4</BaseScore>
+				<Vector>AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="7" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="7" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+jfs: fix slab-out-of-bounds Read in dtSearch
+
+Currently while searching for current page in the sorted entry table
+of the page there is a out of bound access. Added a bound check to fix
+the error.
+
+Dave:
+Set return code to -EIO</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52602</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.1</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="8" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="8" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+UBSAN: array-index-out-of-bounds in dtSplitRoot
+
+Syzkaller reported the following issue:
+
+oop0: detected capacity change from 0 to 32768
+
+UBSAN: array-index-out-of-bounds in fs/jfs/jfs_dtree.c:1971:9
+index -2 is out of range for type &apos;struct dtslot [128]&apos;
+CPU: 0 PID: 3613 Comm: syz-executor270 Not tainted 6.0.0-syzkaller-09423-g493ffd6605b2 #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1b1/0x28e lib/dump_stack.c:106
+ ubsan_epilogue lib/ubsan.c:151 [inline]
+ __ubsan_handle_out_of_bounds+0xdb/0x130 lib/ubsan.c:283
+ dtSplitRoot+0x8d8/0x1900 fs/jfs/jfs_dtree.c:1971
+ dtSplitUp fs/jfs/jfs_dtree.c:985 [inline]
+ dtInsert+0x1189/0x6b80 fs/jfs/jfs_dtree.c:863
+ jfs_mkdir+0x757/0xb00 fs/jfs/namei.c:270
+ vfs_mkdir+0x3b3/0x590 fs/namei.c:4013
+ do_mkdirat+0x279/0x550 fs/namei.c:4038
+ __do_sys_mkdirat fs/namei.c:4053 [inline]
+ __se_sys_mkdirat fs/namei.c:4051 [inline]
+ __x64_sys_mkdirat+0x85/0x90 fs/namei.c:4051
+ do_syscall_x64 arch/x86/entry/common.c:50 [inline]
+ do_syscall_64+0x3d/0xb0 arch/x86/entry/common.c:80
+ entry_SYSCALL_64_after_hwframe+0x63/0xcd
+RIP: 0033:0x7fcdc0113fd9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 &lt;48&gt; 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007ffeb8bc67d8 EFLAGS: 00000246 ORIG_RAX: 0000000000000102
+RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007fcdc0113fd9
+RDX: 0000000000000000 RSI: 0000000020000340 RDI: 0000000000000003
+RBP: 00007fcdc00d37a0 R08: 0000000000000000 R09: 00007fcdc00d37a0
+R10: 00005555559a72c0 R11: 0000000000000246 R12: 00000000f8008000
+R13: 0000000000000000 R14: 00083878000000f8 R15: 0000000000000000
+ &lt;/TASK&gt;
+
+The issue is caused when the value of fsi becomes less than -1.
+The check to break the loop when fsi value becomes -1 is present
+but syzbot was able to produce value less than -1 which cause the error.
+This patch simply add the change for the values less than 0.
+
+The patch is tested via syzbot.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52603</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.1</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+	<Vulnerability Ordinal="9" xmlns="http://www.icasi.org/CVRF/schema/vuln/1.1">
+		<Notes>
+			<Note Title="Vulnerability Description" Type="General" Ordinal="9" xml:lang="en">In the Linux kernel, the following vulnerability has been resolved:
+
+FS:JFS:UBSAN:array-index-out-of-bounds in dbAdjTree
+
+Syzkaller reported the following issue:
+
+UBSAN: array-index-out-of-bounds in fs/jfs/jfs_dmap.c:2867:6
+index 196694 is out of range for type &apos;s8[1365]&apos; (aka &apos;signed char[1365]&apos;)
+CPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106
+ ubsan_epilogue lib/ubsan.c:217 [inline]
+ __ubsan_handle_out_of_bounds+0x11c/0x150 lib/ubsan.c:348
+ dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867
+ dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834
+ dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331
+ dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]
+ dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402
+ txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534
+ txUpdateMap+0x342/0x9e0
+ txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]
+ jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732
+ kthread+0x2d3/0x370 kernel/kthread.c:388
+ ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147
+ ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304
+ &lt;/TASK&gt;
+================================================================================
+Kernel panic - not syncing: UBSAN: panic_on_warn set ...
+CPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023
+Call Trace:
+ &lt;TASK&gt;
+ __dump_stack lib/dump_stack.c:88 [inline]
+ dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106
+ panic+0x30f/0x770 kernel/panic.c:340
+ check_panic_on_warn+0x82/0xa0 kernel/panic.c:236
+ ubsan_epilogue lib/ubsan.c:223 [inline]
+ __ubsan_handle_out_of_bounds+0x13c/0x150 lib/ubsan.c:348
+ dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867
+ dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834
+ dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331
+ dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]
+ dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402
+ txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534
+ txUpdateMap+0x342/0x9e0
+ txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]
+ jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732
+ kthread+0x2d3/0x370 kernel/kthread.c:388
+ ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147
+ ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304
+ &lt;/TASK&gt;
+Kernel Offset: disabled
+Rebooting in 86400 seconds..
+
+The issue is caused when the value of lp becomes greater than
+CTLTREESIZE which is the max size of stree. Adding a simple check
+solves this issue.
+
+Dave:
+As the function returns a void, good error handling
+would require a more intrusive code reorganization, so I modified
+Osama&apos;s patch at use WARN_ON_ONCE for lack of a cleaner option.
+
+The patch is tested via syzbot.</Note>
+		</Notes>
+		<ReleaseDate>2024-03-29</ReleaseDate>
+		<CVE>CVE-2023-52604</CVE>
+		<ProductStatuses>
+			<Status Type="Fixed">
+				<ProductID>openEuler-22.03-LTS-SP2</ProductID>
+			</Status>
+		</ProductStatuses>
+		<Threats>
+			<Threat Type="Impact">
+				<Description>High</Description>
+			</Threat>
+		</Threats>
+		<CVSSScoreSets>
+			<ScoreSet>
+				<BaseScore>7.8</BaseScore>
+				<Vector>AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H</Vector>
+			</ScoreSet>
+		</CVSSScoreSets>
+		<Remediations>
+			<Remediation Type="Vendor Fix">
+				<Description>kernel security update</Description>
+				<DATE>2024-03-29</DATE>
+				<URL>https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349</URL>
+			</Remediation>
+		</Remediations>
+	</Vulnerability>
+</cvrfdoc>

--- a/openeuler/testdata/golden/openEuler-SA-2021-1033.json
+++ b/openeuler/testdata/golden/openEuler-SA-2021-1033.json
@@ -1,0 +1,289 @@
+{
+  "Title": "An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1",
+  "Tracking": {
+    "ID": "openEuler-SA-2021-1033",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2021-02-05",
+    "CurrentReleaseDate": "2021-02-05",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2021-02-05",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "sane-backends security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "SANE (Scanner Access Now Easy) is a sane and simple interface to both local and networked scanners and other image acquisition devices like digital still and video cameras.\\r\\n\\r\\n\nSecurity Fix(es):\\r\\n\\r\\n\nA NULL pointer dereference in sanei_epson_net_read in SANE Backends before 1.0.30 allows a malicious device connected to the same local network as the victim to cause a denial of service, aka GHSL-2020-075.(CVE-2020-12867)\\r\\n\\r\\n",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for sane-backends is now available for openEuler-20.03-LTS and openEuler-20.03-LTS-SP1.\\r\\n\\r\\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "sane-backends",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "openEuler-20.03-LTS"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debuginfo-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-debuginfo-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debugsource-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-debugsource-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-devel-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-devel-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-libs-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-libs-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-cameras-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-drivers-cameras-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-scanners-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-drivers-scanners-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debuginfo-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-debuginfo-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debugsource-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-debugsource-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-devel-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-devel-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-libs-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-libs-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-cameras-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-drivers-cameras-1.0.28-9.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-scanners-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-drivers-scanners-1.0.28-9.oe1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-help-1.0.28-9.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-help-1.0.28-9.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-1.0.28-9.oe1.src.rpm"
+          },
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-1.0.28-9.oe1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debuginfo-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-debuginfo-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debugsource-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-debugsource-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-devel-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-devel-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-libs-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-libs-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-cameras-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-drivers-cameras-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-scanners-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS",
+            "Text": "sane-backends-drivers-scanners-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debuginfo-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-debuginfo-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-debugsource-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-debugsource-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-devel-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-devel-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-libs-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-libs-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-cameras-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-drivers-cameras-1.0.28-9.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "sane-backends-drivers-scanners-1.0.28-9",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "sane-backends-drivers-scanners-1.0.28-9.oe1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1033"
+    },
+    {
+      "URL": "https://openeuler.org/en/security/cve/detail.html?id=CVE-2020-12867"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2020-12867"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2020-12867",
+      "Description": "A NULL pointer dereference in sanei_epson_net_read in SANE Backends before 1.0.30 allows a malicious device connected to the same local network as the victim to cause a denial of service, aka GHSL-2020-075.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS",
+            "openEuler-20.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.5",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2021-1202.json
+++ b/openeuler/testdata/golden/openEuler-SA-2021-1202.json
@@ -1,0 +1,237 @@
+{
+  "Title": "An update for libxml2 is now available for openEuler-20.03-LTS-SP1",
+  "Tracking": {
+    "ID": "openEuler-SA-2021-1202",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2021-06-07",
+    "CurrentReleaseDate": "2021-06-07",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2021-06-07",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "libxml2 security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for libxml2 is now available for openEuler-20.03-LTS-SP1.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "This library allows to manipulate XML files. It includes support to read, modify and write XML and HTML files. There is DTDs support this includes parsing and validation even with complex DtDs, either at parse time or later once the document has been modified. The output can be a simple SAX stream or and in-memory DOM like representations. In this case one can use the built-in XPath and XPointer implementation to select sub nodes or ranges. A flexible Input/Output mechanism is available, with existing HTTP and FTP modules and combined to an URI library.\n\nSecurity Fix(es):\n\nA vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.(CVE-2021-3537)\n\nThere's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.(CVE-2021-3518)\n\nThere is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.(CVE-2021-3517)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for libxml2 is now available for openEuler-20.03-LTS-SP1.\n\nopenEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "High",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "libxml2",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "libxml2-debugsource-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-debugsource-2.9.10-16.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "libxml2-debuginfo-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-debuginfo-2.9.10-16.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "libxml2-devel-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-devel-2.9.10-16.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-libxml2-2.9.10-16.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-libxml2-2.9.10-16.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-2.9.10-16.oe1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "libxml2-help-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-help-2.9.10-16.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-2.9.10-16.oe1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-2.9.10-16.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-libxml2-2.9.10-16.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "libxml2-debugsource-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-debugsource-2.9.10-16.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-libxml2-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-libxml2-2.9.10-16.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "libxml2-debuginfo-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-debuginfo-2.9.10-16.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "libxml2-devel-2.9.10-16",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "libxml2-devel-2.9.10-16.oe1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1202"
+    },
+    {
+      "URL": "https://openeuler.org/en/security/cve/detail.html?id=CVE-2021-3517"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2021-3517"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2021-3537",
+      "Description": "A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.9",
+        "Vector": "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2021-3518",
+      "Description": "There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "8.8",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2021-3517",
+      "Description": "There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "8.6",
+        "Vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2021-1480.json
+++ b/openeuler/testdata/golden/openEuler-SA-2021-1480.json
@@ -1,0 +1,147 @@
+{
+  "Title": "An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2",
+  "Tracking": {
+    "ID": "openEuler-SA-2021-1480",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2021-12-31",
+    "CurrentReleaseDate": "2021-12-31",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2021-12-31",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "rubygem-bundler security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "Library and utilities to manage a Ruby application's gem dependencies.\n\nSecurity Fix(es):\n\n`Bundler` is a package for managing application dependencies in Ruby. In `bundler` versions before 2.2.33, when working with untrusted and apparently harmless `Gemfile`'s, it is not expected that they lead to execution of external code, unless that's explicit in the ruby code inside the `Gemfile` itself. However, if the `Gemfile` includes `gem` entries that use the `git` option with invalid, but seemingly harmless, values with a leading dash, this can be False. To handle dependencies that come from a Git repository instead of a registry, Bundler uses various commands, such as `git clone`. These commands are being constructed using user input (e.g. the repository URL). When building the commands, Bundler versions before 2.2.33 correctly avoid Command Injection vulnerabilities by passing an array of arguments instead of a command string. However, there is the possibility that a user input starts with a dash (`-`) and is therefore treated as an optional argument instead of a positional one. This can lead to Code Execution because some of the commands have options that can be leveraged to run arbitrary executables. Since this value comes from the `Gemfile` file, it can contain any character, including a leading dash. To exploit this vulnerability, an attacker has to craft a directory containing a `Gemfile` file that declares a dependency that is located in a Git repository. This dependency has to have a Git URL in the form of `-u./payload`. This URL will be used to construct a Git clone command but will be interpreted as the upload-pack argument. Then this directory needs to be shared with the victim, who then needs to run a command that evaluates the Gemfile, such as `bundle lock`, inside. This vulnerability can lead to Arbitrary Code Execution, which could potentially lead to the takeover of the system. However, the exploitability is very low, because it requires a lot of user interaction. Bundler 2.2.33 has patched this problem by inserting `--` as an argument before any positional arguments to those Git commands that were affected by this issue. Regardless of whether users can upgrade or not, they should review any untrustred `Gemfile`'s before running any `bundler` commands that may read them, since they can contain arbitrary ruby code.(CVE-2021-43809)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for rubygem-bundler is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2.\n\nopenEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "High",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "rubygem-bundler",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "openEuler-20.03-LTS-SP2"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "rubygem-bundler-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "rubygem-bundler-2.2.33-1.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "rubygem-bundler-help-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "rubygem-bundler-help-2.2.33-1.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "rubygem-bundler-help-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "rubygem-bundler-help-2.2.33-1.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "rubygem-bundler-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "rubygem-bundler-2.2.33-1.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "rubygem-bundler-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "rubygem-bundler-2.2.33-1.oe1.src.rpm"
+          },
+          {
+            "ProductID": "rubygem-bundler-2.2.33-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "rubygem-bundler-2.2.33-1.oe1.src.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2021-1480"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-43809"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2021-43809"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2021-43809",
+      "Description": "`Bundler` is a package for managing application dependencies in Ruby. In `bundler` versions before 2.2.33, when working with untrusted and apparently harmless `Gemfile` s, it is not expected that they lead to execution of external code, unless that s explicit in the ruby code inside the `Gemfile` itself. However, if the `Gemfile` includes `gem` entries that use the `git` option with invalid, but seemingly harmless, values with a leading dash, this can be False. To handle dependencies that come from a Git repository instead of a registry, Bundler uses various commands, such as `git clone`. These commands are being constructed using user input (e.g. the repository URL). When building the commands, Bundler versions before 2.2.33 correctly avoid Command Injection vulnerabilities by passing an array of arguments instead of a command string. However, there is the possibility that a user input starts with a dash (`-`) and is therefore treated as an optional argument instead of a positional one. This can lead to Code Execution because some of the commands have options that can be leveraged to run arbitrary executables. Since this value comes from the `Gemfile` file, it can contain any character, including a leading dash. To exploit this vulnerability, an attacker has to craft a directory containing a `Gemfile` file that declares a dependency that is located in a Git repository. This dependency has to have a Git URL in the form of `-u./payload`. This URL will be used to construct a Git clone command but will be interpreted as the upload-pack argument. Then this directory needs to be shared with the victim, who then needs to run a command that evaluates the Gemfile, such as `bundle lock`, inside. This vulnerability can lead to Arbitrary Code Execution, which could potentially lead to the takeover of the system. However, the exploitability is very low, because it requires a lot of user interaction. Bundler 2.2.33 has patched this problem by inserting `--` as an argument before any positional arguments to those Git commands that were affected by this issue. Regardless of whether users can upgrade or not, they should review any untrustred `Gemfile` s before running any `bundler` commands that may read them, since they can contain arbitrary ruby code.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.3",
+        "Vector": "AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2022-1485.json
+++ b/openeuler/testdata/golden/openEuler-SA-2022-1485.json
@@ -1,0 +1,324 @@
+{
+  "Title": "An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3",
+  "Tracking": {
+    "ID": "openEuler-SA-2022-1485",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2022-01-07",
+    "CurrentReleaseDate": "2022-01-07",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2022-01-07",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "numpy security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "A fast multidimensional array facility for Python.\n\nSecurity Fix(es):\n\nBuffer overflow in the array_from_pyobj function of fortranobject.c in NumPy \u003c 1.19, which allows attackers to conduct a Denial of Service attacks by carefully constructing an array with negative values.(CVE-2021-41496)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for numpy is now available for openEuler-20.03-LTS-SP1 and openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.\n\nopenEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "High",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "numpy",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "openEuler-20.03-LTS-SP2"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python3-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python2-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python2-numpy-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "numpy-1.16.5-4.oe1.src.rpm"
+          },
+          {
+            "ProductID": "numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "numpy-1.16.5-4.oe1.src.rpm"
+          },
+          {
+            "ProductID": "numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "numpy-1.16.5-4.oe1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python2-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python3-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python2-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python2-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debugsource-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "numpy-debugsource-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python2-numpy-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python2-numpy-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "numpy-debuginfo-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "numpy-debuginfo-1.16.5-4.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-numpy-f2py-1.16.5-4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-numpy-f2py-1.16.5-4.oe1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1485"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-41496"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2021-41496"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2021-41496",
+      "Description": "Buffer overflow in the array_from_pyobj function of fortranobject.c in NumPy \u003c 1.19, which allows attackers to conduct a Denial of Service attacks by carefully constructing an array with negative values.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP2",
+            "openEuler-20.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.5",
+        "Vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2022-1580.json
+++ b/openeuler/testdata/golden/openEuler-SA-2022-1580.json
@@ -1,0 +1,345 @@
+{
+  "Title": "An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3",
+  "Tracking": {
+    "ID": "openEuler-SA-2022-1580",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2022-03-19",
+    "CurrentReleaseDate": "2022-03-19",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2022-03-19",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "vim security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "Vim is an advanced text editor that seeks to provide the power of the de-facto Unix editor 'Vi', with a more complete feature set. Vim is a highly configurable text editor built to enable efficient text editing. It is an improved version of the vi editor distributed with most UNIX systems.\n\nSecurity Fix(es):\n\nUse of Out-of-range Pointer Offset in GitHub repository vim/vim prior to 8.2.4418.(CVE-2022-0685)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for vim is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP2 and openEuler-20.03-LTS-SP3.\n\nopenEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "High",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "vim",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "openEuler-20.03-LTS-SP2"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-common-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-debugsource-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-enhanced-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-X11-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-minimal-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-debuginfo-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-enhanced-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-debuginfo-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-common-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-X11-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-debugsource-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-minimal-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-debugsource-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-minimal-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-debuginfo-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-X11-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-common-8.2-22.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-enhanced-8.2-22.oe1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "vim-filesystem-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-filesystem-8.2-22.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "vim-filesystem-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-filesystem-8.2-22.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "vim-filesystem-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-filesystem-8.2-22.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "vim-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-8.2-22.oe1.src.rpm"
+          },
+          {
+            "ProductID": "vim-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-8.2-22.oe1.src.rpm"
+          },
+          {
+            "ProductID": "vim-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-8.2-22.oe1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-minimal-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-X11-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-debuginfo-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-enhanced-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-debugsource-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "vim-common-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-enhanced-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-X11-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-minimal-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-common-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-debuginfo-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP2",
+            "Text": "vim-debugsource-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-enhanced-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-enhanced-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debuginfo-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-debuginfo-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-common-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-common-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-minimal-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-minimal-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-X11-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-X11-8.2-22.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "vim-debugsource-8.2-22",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "vim-debugsource-8.2-22.oe1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1580"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-0685"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2022-0685"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2022-0685",
+      "Description": "Use of Out-of-range Pointer Offset in GitHub repository vim/vim prior to 8.2.4418.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP2",
+            "openEuler-20.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.8",
+        "Vector": "AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2022-1693.json
+++ b/openeuler/testdata/golden/openEuler-SA-2022-1693.json
@@ -1,0 +1,126 @@
+{
+  "Title": "An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3",
+  "Tracking": {
+    "ID": "openEuler-SA-2022-1693",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2022-06-02",
+    "CurrentReleaseDate": "2022-06-02",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2022-06-02",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "python-XStatic-jquery-ui security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "jquery-ui javascript library packaged for setuptools (easy_install) / pip. This package is intended to be used by **any** project that needs these files. It intentionally does **not** provide any extra code except some metadata **nor** has any extra requirements. You MAY use some minimal support code from the XStatic base package, if you like. You can find more info about the xstatic packaging way in the package `XStatic`.\n\nSecurity Fix(es):\n\njQuery-UI is the official jQuery user interface library. Prior to version 1.13.0, accepting the value of various `*Text` options of the Datepicker widget from untrusted sources may execute untrusted code. The issue is fixed in jQuery UI 1.13.0. The values passed to various `*Text` options are now always treated as pure text, not HTML. A workaround is to not accept the value of the `*Text` options from untrusted sources.(CVE-2021-41183)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for python-XStatic-jquery-ui is now available for openEuler-20.03-LTS-SP3.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "python-XStatic-jquery-ui",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "python3-XStatic-jquery-ui-1.12.1.1-2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-XStatic-jquery-ui-1.12.1.1-2.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "python-XStatic-jquery-ui-help-1.12.1.1-2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python-XStatic-jquery-ui-help-1.12.1.1-2.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "python-XStatic-jquery-ui-1.12.1.1-2",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python-XStatic-jquery-ui-1.12.1.1-2.oe1.src.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1693"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2021-41183"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2021-41183"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2021-41183",
+      "Description": "jQuery-UI is the official jQuery user interface library. Prior to version 1.13.0, accepting the value of various `*Text` options of the Datepicker widget from untrusted sources may execute untrusted code. The issue is fixed in jQuery UI 1.13.0. The values passed to various `*Text` options are now always treated as pure text, not HTML. A workaround is to not accept the value of the `*Text` options from untrusted sources.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "6.1",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2022-1704.json
+++ b/openeuler/testdata/golden/openEuler-SA-2022-1704.json
@@ -1,0 +1,174 @@
+{
+  "Title": "An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS",
+  "Tracking": {
+    "ID": "openEuler-SA-2022-1704",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2022-06-10",
+    "CurrentReleaseDate": "2022-06-10",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2022-06-10",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "runc security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "runc is a CLI tool for spawning and running containers according to the OCI specification.\n\nSecurity Fix(es):\n\nrunc is a CLI tool for spawning and running containers on Linux according to the OCI specification. A bug was found in runc prior to version 1.1.2 where `runc exec --cap` created processes with non-empty inheritable Linux process capabilities, creating an atypical Linux environment and enabling programs with inheritable file capabilities to elevate those capabilities to the permitted set during execve(2). This bug did not affect the container security sandbox as the inheritable set never contained more capabilities than were included in the container's bounding set. This bug has been fixed in runc 1.1.2. This fix changes `runc exec --cap` behavior such that the additional capabilities granted to the process being executed (as specified via `--cap` arguments) do not include inheritable capabilities. In addition, `runc spec` is changed to not set any inheritable capabilities in the created example OCI spec (`config.json`) file.(CVE-2022-29162)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for runc is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3 and openEuler-22.03-LTS.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "runc",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "openEuler-22.03-LTS"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-203",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "docker-runc-1.0.0.rc3-203.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-204",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "docker-runc-1.0.0.rc3-204.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-301",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "docker-runc-1.0.0.rc3-301.oe2203.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-203",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "docker-runc-1.0.0.rc3-203.oe1.src.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-204",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "docker-runc-1.0.0.rc3-204.oe1.src.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-301",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "docker-runc-1.0.0.rc3-301.oe2203.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-203",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "docker-runc-1.0.0.rc3-203.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-204",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "docker-runc-1.0.0.rc3-204.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "docker-runc-1.0.0.rc3-301",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "docker-runc-1.0.0.rc3-301.oe2203.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2022-1704"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-29162"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2022-29162"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2022-29162",
+      "Description": "runc is a CLI tool for spawning and running containers on Linux according to the OCI specification. A bug was found in runc prior to version 1.1.2 where `runc exec --cap` created processes with non-empty inheritable Linux process capabilities, creating an atypical Linux environment and enabling programs with inheritable file capabilities to elevate those capabilities to the permitted set during execve(2). This bug did not affect the container security sandbox as the inheritable set never contained more capabilities than were included in the container s bounding set. This bug has been fixed in runc 1.1.2. This fix changes `runc exec --cap` behavior such that the additional capabilities granted to the process being executed (as specified via `--cap` arguments) do not include inheritable capabilities. In addition, `runc spec` is changed to not set any inheritable capabilities in the created example OCI spec (`config.json`) file.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP3",
+            "openEuler-22.03-LTS"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.9",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2023-1006.json
+++ b/openeuler/testdata/golden/openEuler-SA-2023-1006.json
@@ -1,0 +1,183 @@
+{
+  "Title": "An update for curl is now available for openEuler-20.03-LTS-SP3",
+  "Tracking": {
+    "ID": "openEuler-SA-2023-1006",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2023-01-06",
+    "CurrentReleaseDate": "2023-01-06",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2023-01-06",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "curl security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for curl is now available for openEuler-20.03-LTS-SP3.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "cURL is a computer software project providing a library (libcurl) and command-line tool (curl) for transferring data using various protocols.\n\nSecurity Fix(es):\n\nA vulnerability was found in curl. In this issue, curl can be asked to tunnel all protocols virtually it supports through an HTTP proxy. HTTP proxies can deny these tunnel operations using an appropriate HTTP error response code. When getting denied to tunnel the specific SMB or TELNET protocols, curl can use a heap-allocated struct after it has been freed and shut down the code path in its transfer.(CVE-2022-43552)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for curl is now available for openEuler-20.03-LTS-SP3.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "curl",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "curl-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-7.71.1-20.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "curl-debuginfo-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-debuginfo-7.71.1-20.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "libcurl-devel-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "libcurl-devel-7.71.1-20.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "libcurl-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "libcurl-7.71.1-20.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "curl-debugsource-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-debugsource-7.71.1-20.oe1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "curl-help-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-help-7.71.1-20.oe1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "curl-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-7.71.1-20.oe1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "libcurl-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "libcurl-7.71.1-20.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "curl-debuginfo-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-debuginfo-7.71.1-20.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "libcurl-devel-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "libcurl-devel-7.71.1-20.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "curl-debugsource-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-debugsource-7.71.1-20.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "curl-7.71.1-20",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "curl-7.71.1-20.oe1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1006"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-43552"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2022-43552"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2022-43552",
+      "Description": "A vulnerability was found in curl. In this issue, curl can be asked to tunnel all protocols virtually it supports through an HTTP proxy. HTTP proxies can deny these tunnel operations using an appropriate HTTP error response code. When getting denied to tunnel the specific SMB or TELNET protocols, curl can use a heap-allocated struct after it has been freed and shut down the code path in its transfer.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.9",
+        "Vector": "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2023-1010.json
+++ b/openeuler/testdata/golden/openEuler-SA-2023-1010.json
@@ -1,0 +1,526 @@
+{
+  "Title": "An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1",
+  "Tracking": {
+    "ID": "openEuler-SA-2023-1010",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2023-01-06",
+    "CurrentReleaseDate": "2023-01-06",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2023-01-06",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "net-snmp security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "Net-SNMP is a suite of applications used to implement SNMP v1, SNMP v2c and SNMP v3 using both IPv4 and IPv6. The suite includes:\n\n\t\t- An extensible agent for responding to SNMP queries including built-in support for a wide range of MIB information modules\n\t\t- Command-line applications to retrieve and manipulate information from SNMP-capable devices\n\t\t- A daemon application for receiving SNMP notifications\n\t\t- A library for developing new SNMP applications, with C and Perl APIs\n\t\t- A graphical MIB browser.\n\nSecurity Fix(es):\n\nhandle_ipv6IpForwarding in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.4.3 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.(CVE-2022-44793)\n\nhandle_ipDefaultTTL in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.8 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker (who has write access) to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.(CVE-2022-44792)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for net-snmp is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP3,openEuler-22.03-LTS and openEuler-22.03-LTS-SP1.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "net-snmp",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "openEuler-20.03-LTS-SP3"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "openEuler-22.03-LTS"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "openEuler-22.03-LTS-SP1"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "python3-net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-net-snmp-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-gui-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-libs-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-perl-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-debugsource-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-debuginfo-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-devel-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-debugsource-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-gui-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-debuginfo-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-devel-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-net-snmp-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-libs-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-perl-5.9-8.oe1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-gui-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-debugsource-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-devel-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-libs-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-debuginfo-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-perl-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "python3-net-snmp-5.9.1-5.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-debugsource-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "python3-net-snmp-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-gui-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-debuginfo-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-perl-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-devel-5.9.1-5.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-libs-5.9.1-5.oe2203sp1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "noarch",
+        "Productions": [
+          {
+            "ProductID": "net-snmp-help-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-help-5.9-8.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "net-snmp-help-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-help-5.9-8.oe1.noarch.rpm"
+          },
+          {
+            "ProductID": "net-snmp-help-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-help-5.9.1-5.oe2203.noarch.rpm"
+          },
+          {
+            "ProductID": "net-snmp-help-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-help-5.9.1-5.oe2203sp1.noarch.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-5.9-8.oe1.src.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-5.9-8.oe1.src.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-5.9.1-5.oe2203.src.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-5.9.1-5.oe2203sp1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "net-snmp-libs-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-libs-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-gui-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-debuginfo-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-perl-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "python3-net-snmp-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-devel-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "net-snmp-debugsource-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "python3-net-snmp-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-gui-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-libs-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-debuginfo-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-perl-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-debugsource-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9-8",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP3",
+            "Text": "net-snmp-devel-5.9-8.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-perl-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-gui-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-libs-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-devel-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-debuginfo-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "python3-net-snmp-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "net-snmp-debugsource-5.9.1-5.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debuginfo-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-debuginfo-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-perl-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-perl-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-devel-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-devel-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-debugsource-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-debugsource-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "python3-net-snmp-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-libs-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-libs-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-gui-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-gui-5.9.1-5.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "net-snmp-5.9.1-5",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "net-snmp-5.9.1-5.oe2203sp1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1010"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2022-44792"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2022-44792"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2022-44793",
+      "Description": "handle_ipv6IpForwarding in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.4.3 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP3",
+            "openEuler-22.03-LTS",
+            "openEuler-22.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "6.5",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2022-44792",
+      "Description": "handle_ipDefaultTTL in agent/mibgroup/ip-mib/ip_scalars.c in Net-SNMP 5.8 through 5.9.3 has a NULL Pointer Exception bug that can be used by a remote attacker (who has write access) to cause the instance to crash via a crafted UDP packet, resulting in Denial of Service.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP3",
+            "openEuler-22.03-LTS",
+            "openEuler-22.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "6.5",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2023-1374.json
+++ b/openeuler/testdata/golden/openEuler-SA-2023-1374.json
@@ -1,0 +1,194 @@
+{
+  "Title": "An update for wireshark is now available for openEuler-22.03-LTS-SP1",
+  "Tracking": {
+    "ID": "openEuler-SA-2023-1374",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2023-06-27",
+    "CurrentReleaseDate": "2023-06-27",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2023-06-27",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "wireshark security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for wireshark is now available for openEuler-22.03-LTS-SP1.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "Wireshark allows you to examine protocol data stored in files or as it is captured from wired or wireless (WiFi or Bluetooth) networks, USB devices, and many other sources.  It supports dozens of protocol capture file formats and understands more than a thousand protocols. It has many powerful features including a rich display filter language and the ability to reassemble multiple protocol packets in order to, for example, view a complete TCP stream, save the contents of a file which was transferred over HTTP or CIFS, or play back an RTP audio stream.\n\nSecurity Fix(es):\n\nXRA dissector infinite loop in Wireshark 4.0.0 to 4.0.5 and 3.6.0 to 3.6.13 allows denial of service via packet injection or crafted capture file(CVE-2023-2952)\n\nDue to failure in validating the length provided by an attacker-crafted MSMMS packet, Wireshark version 4.0.5 and prior, in an unusual configuration, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark(CVE-2023-0667)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for wireshark is now available for openEuler-22.03-LTS-SP1.\n\nopenEuler Security has rated this update as having a security impact of critical. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Critical",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "wireshark",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-22.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "openEuler-22.03-LTS-SP1"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "wireshark-devel-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-devel-3.6.14-1.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "wireshark-debugsource-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-debugsource-3.6.14-1.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "wireshark-help-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-help-3.6.14-1.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "wireshark-debuginfo-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-debuginfo-3.6.14-1.oe2203sp1.aarch64.rpm"
+          },
+          {
+            "ProductID": "wireshark-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-3.6.14-1.oe2203sp1.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "wireshark-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-3.6.14-1.oe2203sp1.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "wireshark-debugsource-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-debugsource-3.6.14-1.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "wireshark-help-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-help-3.6.14-1.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "wireshark-devel-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-devel-3.6.14-1.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "wireshark-debuginfo-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-debuginfo-3.6.14-1.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "wireshark-3.6.14-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "wireshark-3.6.14-1.oe2203sp1.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2023-1374"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-0667"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2023-0667"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2023-2952",
+      "Description": "XRA dissector infinite loop in Wireshark 4.0.0 to 4.0.5 and 3.6.0 to 3.6.13 allows denial of service via packet injection or crafted capture file",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "6.5",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-0667",
+      "Description": "Due to failure in validating the length provided by an attacker-crafted MSMMS packet, Wireshark version 4.0.5 and prior, in an unusual configuration, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Critical"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP1"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "9.8",
+        "Vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2024-1151.json
+++ b/openeuler/testdata/golden/openEuler-SA-2024-1151.json
@@ -1,0 +1,304 @@
+{
+  "Title": "An update for openjdk-11 is now available for openEuler-22.03-LTS",
+  "Tracking": {
+    "ID": "openEuler-SA-2024-1151",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2024-02-08",
+    "CurrentReleaseDate": "2024-02-08",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2024-02-08",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "openjdk-11 security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for openjdk-11 is now available for openEuler-22.03-LTS.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "The OpenJDK runtime environment.\n\nSecurity Fix(es):\n\nDifficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service.(CVE-2024-20919)\n\nDifficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security.(CVE-2024-20921)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for openjdk-11 is now available for openEuler-22.03-LTS.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "openjdk-11",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-22.03-LTS",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "openEuler-22.03-LTS"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "java-11-openjdk-devel-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-devel-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-devel-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-devel-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-jmods-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-jmods-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-javadoc-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-javadoc-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-demo-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-demo-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-jmods-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-jmods-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-src-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-src-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-debuginfo-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-debuginfo-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-debugsource-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-debugsource-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-headless-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-headless-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-src-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-src-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-headless-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-headless-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-javadoc-zip-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-javadoc-zip-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-demo-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-demo-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-slowdebug-11.0.22.7-0.oe2203.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "java-11-openjdk-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-11.0.22.7-0.oe2203.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "java-11-openjdk-javadoc-zip-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-javadoc-zip-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-demo-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-demo-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-devel-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-devel-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-headless-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-headless-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-jmods-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-jmods-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-src-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-src-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-jmods-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-jmods-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-debuginfo-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-debuginfo-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-demo-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-demo-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-javadoc-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-javadoc-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-debugsource-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-debugsource-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-headless-slowdebug-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-headless-slowdebug-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-src-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-src-11.0.22.7-0.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "java-11-openjdk-devel-11.0.22.7-0",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "java-11-openjdk-devel-11.0.22.7-0.oe2203.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1151"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2024-20921"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2024-20921"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2024-20919",
+      "Description": "Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.9",
+        "Vector": "AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+      }
+    },
+    {
+      "CVE": "CVE-2024-20921",
+      "Description": "Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.9",
+        "Vector": "AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2024-1295.json
+++ b/openeuler/testdata/golden/openEuler-SA-2024-1295.json
@@ -1,0 +1,228 @@
+{
+  "Title": "An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3",
+  "Tracking": {
+    "ID": "openEuler-SA-2024-1295",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2024-03-22",
+    "CurrentReleaseDate": "2024-03-22",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2024-03-22",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "microcode_ctl security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "This is a tool to transform and deploy microcode update for x86 CPUs.\n\nSecurity Fix(es):\n\nNon-transparent sharing of return predictor targets between contexts in some Intel(R) Processors may allow an authorized user to potentially enable information disclosure via local access.(CVE-2023-38575)\n\nProtection mechanism failure of bus lock regulator for some Intel(R) Processors may allow an unauthenticated user to potentially enable denial of service via network access.(CVE-2023-39368)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for microcode_ctl is now available for openEuler-20.03-LTS-SP1,openEuler-20.03-LTS-SP4,openEuler-22.03-LTS,openEuler-22.03-LTS-SP1,openEuler-22.03-LTS-SP2 and openEuler-22.03-LTS-SP3.\n\nopenEuler Security has rated this update as having a security impact of medium. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "Medium",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "microcode_ctl",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-20.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "openEuler-20.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-20.03-LTS-SP4",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP4",
+            "Text": "openEuler-20.03-LTS-SP4"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "openEuler-22.03-LTS"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS-SP1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "openEuler-22.03-LTS-SP1"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS-SP2",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "openEuler-22.03-LTS-SP2"
+          },
+          {
+            "ProductID": "openEuler-22.03-LTS-SP3",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP3",
+            "Text": "openEuler-22.03-LTS-SP3"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "microcode_ctl-20240312-1.oe1.src.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP4",
+            "Text": "microcode_ctl-20240312-1.oe2003sp4.src.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "microcode_ctl-20240312-1.oe2203.src.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "microcode_ctl-20240312-1.oe2203sp1.src.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "microcode_ctl-20240312-1.oe2203sp2.src.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP3",
+            "Text": "microcode_ctl-20240312-1.oe2203sp3.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP1",
+            "Text": "microcode_ctl-20240312-1.oe1.x86_64.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:20.03-LTS-SP4",
+            "Text": "microcode_ctl-20240312-1.oe2003sp4.x86_64.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS",
+            "Text": "microcode_ctl-20240312-1.oe2203.x86_64.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP1",
+            "Text": "microcode_ctl-20240312-1.oe2203sp1.x86_64.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "microcode_ctl-20240312-1.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "microcode_ctl-20240312-1",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP3",
+            "Text": "microcode_ctl-20240312-1.oe2203sp3.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1295"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-39368"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2023-39368"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2023-38575",
+      "Description": "Non-transparent sharing of return predictor targets between contexts in some Intel(R) Processors may allow an authorized user to potentially enable information disclosure via local access.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP4",
+            "openEuler-22.03-LTS",
+            "openEuler-22.03-LTS-SP1",
+            "openEuler-22.03-LTS-SP2",
+            "openEuler-22.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.5",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      }
+    },
+    {
+      "CVE": "CVE-2023-39368",
+      "Description": "Protection mechanism failure of bus lock regulator for some Intel(R) Processors may allow an unauthenticated user to potentially enable denial of service via network access.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-20.03-LTS-SP1",
+            "openEuler-20.03-LTS-SP4",
+            "openEuler-22.03-LTS",
+            "openEuler-22.03-LTS-SP1",
+            "openEuler-22.03-LTS-SP2",
+            "openEuler-22.03-LTS-SP3"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "6.5",
+        "Vector": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/golden/openEuler-SA-2024-1349.json
+++ b/openeuler/testdata/golden/openEuler-SA-2024-1349.json
@@ -1,0 +1,428 @@
+{
+  "Title": "An update for kernel is now available for openEuler-22.03-LTS-SP2",
+  "Tracking": {
+    "ID": "openEuler-SA-2024-1349",
+    "Status": "Final",
+    "Version": "1.0",
+    "InitialReleaseDate": "2024-03-29",
+    "CurrentReleaseDate": "2024-03-29",
+    "RevisionHistory": [
+      {
+        "Number": "1.0",
+        "Date": "2024-03-29",
+        "Description": "Initial"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "kernel security update",
+      "Title": "Synopsis",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for kernel is now available for openEuler-22.03-LTS-SP2.",
+      "Title": "Summary",
+      "Type": "General"
+    },
+    {
+      "Text": "The Linux Kernel, the operating system core itself.\n\nSecurity Fix(es):\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nnet/sched: act_ct: fix wild memory access when clearing fragments\n\nwhile testing re-assembly/re-fragmentation using act_ct, it's possible to\nobserve a crash like the following one:\n\n KASAN: maybe wild-memory-access in range [0x0001000000000448-0x000100000000044f]\n CPU: 50 PID: 0 Comm: swapper/50 Tainted: G S                5.12.0-rc7+ #424\n Hardware name: Dell Inc. PowerEdge R730/072T6D, BIOS 2.4.3 01/17/2017\n RIP: 0010:inet_frag_rbtree_purge+0x50/0xc0\n Code: 00 fc ff df 48 89 c3 31 ed 48 89 df e8 a9 7a 38 ff 4c 89 fe 48 89 df 49 89 c6 e8 5b 3a 38 ff 48 8d 7b 40 48 89 f8 48 c1 e8 03 \u003c42\u003e 80 3c 20 00 75 59 48 8d bb d0 00 00 00 4c 8b 6b 40 48 89 f8 48\n RSP: 0018:ffff888c31449db8 EFLAGS: 00010203\n RAX: 0000200000000089 RBX: 000100000000040e RCX: ffffffff989eb960\n RDX: 0000000000000140 RSI: ffffffff97cfb977 RDI: 000100000000044e\n RBP: 0000000000000900 R08: 0000000000000000 R09: ffffed1186289350\n R10: 0000000000000003 R11: ffffed1186289350 R12: dffffc0000000000\n R13: 000100000000040e R14: 0000000000000000 R15: ffff888155e02160\n FS:  0000000000000000(0000) GS:ffff888c31440000(0000) knlGS:0000000000000000\n CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033\n CR2: 00005600cb70a5b8 CR3: 0000000a2c014005 CR4: 00000000003706e0\n DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000\n DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400\n Call Trace:\n  \u003cIRQ\u003e\n  inet_frag_destroy+0xa9/0x150\n  call_timer_fn+0x2d/0x180\n  run_timer_softirq+0x4fe/0xe70\n  __do_softirq+0x197/0x5a0\n  irq_exit_rcu+0x1de/0x200\n  sysvec_apic_timer_interrupt+0x6b/0x80\n  \u003c/IRQ\u003e\n\nwhen act_ct temporarily stores an IP fragment, restoring the skb qdisc cb\nresults in putting random data in FRAG_CB(), and this causes those \"wild\"\nmemory accesses later, when the rbtree is purged. Never overwrite the skb\ncb in case tcf_ct_handle_fragments() returns -EINPROGRESS.(CVE-2021-47014)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nudp: skip L4 aggregation for UDP tunnel packets\n\nIf NETIF_F_GRO_FRAGLIST or NETIF_F_GRO_UDP_FWD are enabled, and there\nare UDP tunnels available in the system, udp_gro_receive() could end-up\ndoing L4 aggregation (either SKB_GSO_UDP_L4 or SKB_GSO_FRAGLIST) at\nthe outer UDP tunnel level for packets effectively carrying and UDP\ntunnel header.\n\nThat could cause inner protocol corruption. If e.g. the relevant\npackets carry a vxlan header, different vxlan ids will be ignored/\naggregated to the same GSO packet. Inner headers will be ignored, too,\nso that e.g. TCP over vxlan push packets will be held in the GRO\nengine till the next flush, etc.\n\nJust skip the SKB_GSO_UDP_L4 and SKB_GSO_FRAGLIST code path if the\ncurrent packet could land in a UDP tunnel, and let udp_gro_receive()\ndo GRO via udp_sk(sk)-\u003egro_receive.\n\nThe check implemented in this patch is broader than what is strictly\nneeded, as the existing UDP tunnel could be e.g. configured on top of\na different device: we could end-up skipping GRO at-all for some packets.\n\nAnyhow, that is a very thin corner case and covering it will add quite\na bit of complexity.\n\nv1 -\u003e v2:\n - hopefully clarify the commit message(CVE-2021-47036)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nmedia: pvrusb2: fix use after free on context disconnection\n\nUpon module load, a kthread is created targeting the\npvr2_context_thread_func function, which may call pvr2_context_destroy\nand thus call kfree() on the context object. However, that might happen\nbefore the usb hub_event handler is able to notify the driver. This\npatch adds a sanity check before the invalid read reported by syzbot,\nwithin the context disconnection call stack.(CVE-2023-52445)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nblock: add check that partition length needs to be aligned with block size\n\nBefore calling add partition or resize partition, there is no check\non whether the length is aligned with the logical block size.\nIf the logical block size of the disk is larger than 512 bytes,\nthen the partition size maybe not the multiple of the logical block size,\nand when the last sector is read, bio_truncate() will adjust the bio size,\nresulting in an IO error if the size of the read command is smaller than\nthe logical block size.If integrity data is supported, this will also\nresult in a null pointer dereference when calling bio_integrity_free.(CVE-2023-52458)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nnet: usb: smsc75xx: Fix uninit-value access in __smsc75xx_read_reg\n\nsyzbot reported the following uninit-value access issue:\n\n=====================================================\nBUG: KMSAN: uninit-value in smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]\nBUG: KMSAN: uninit-value in smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482\nCPU: 0 PID: 8696 Comm: kworker/0:3 Not tainted 5.8.0-rc5-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011\nWorkqueue: usb_hub_wq hub_event\nCall Trace:\n __dump_stack lib/dump_stack.c:77 [inline]\n dump_stack+0x21c/0x280 lib/dump_stack.c:118\n kmsan_report+0xf7/0x1e0 mm/kmsan/kmsan_report.c:121\n __msan_warning+0x58/0xa0 mm/kmsan/kmsan_instr.c:215\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]\n smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482\n usbnet_probe+0x1152/0x3f90 drivers/net/usb/usbnet.c:1737\n usb_probe_interface+0xece/0x1550 drivers/usb/core/driver.c:374\n really_probe+0xf20/0x20b0 drivers/base/dd.c:529\n driver_probe_device+0x293/0x390 drivers/base/dd.c:701\n __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807\n bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431\n __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873\n device_initial_probe+0x4a/0x60 drivers/base/dd.c:920\n bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491\n device_add+0x3b0e/0x40d0 drivers/base/core.c:2680\n usb_set_configuration+0x380f/0x3f10 drivers/usb/core/message.c:2032\n usb_generic_driver_probe+0x138/0x300 drivers/usb/core/generic.c:241\n usb_probe_device+0x311/0x490 drivers/usb/core/driver.c:272\n really_probe+0xf20/0x20b0 drivers/base/dd.c:529\n driver_probe_device+0x293/0x390 drivers/base/dd.c:701\n __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807\n bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431\n __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873\n device_initial_probe+0x4a/0x60 drivers/base/dd.c:920\n bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491\n device_add+0x3b0e/0x40d0 drivers/base/core.c:2680\n usb_new_device+0x1bd4/0x2a30 drivers/usb/core/hub.c:2554\n hub_port_connect drivers/usb/core/hub.c:5208 [inline]\n hub_port_connect_change drivers/usb/core/hub.c:5348 [inline]\n port_event drivers/usb/core/hub.c:5494 [inline]\n hub_event+0x5e7b/0x8a70 drivers/usb/core/hub.c:5576\n process_one_work+0x1688/0x2140 kernel/workqueue.c:2269\n worker_thread+0x10bc/0x2730 kernel/workqueue.c:2415\n kthread+0x551/0x590 kernel/kthread.c:292\n ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:293\n\nLocal variable ----buf.i87@smsc75xx_bind created at:\n __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]\n smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482\n __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]\n smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482\n\nThis issue is caused because usbnet_read_cmd() reads less bytes than requested\n(zero byte in the reproducer). In this case, 'buf' is not properly filled.\n\nThis patch fixes the issue by returning -ENODATA if usbnet_read_cmd() reads\nless bytes than requested.(CVE-2023-52528)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nwifi: wfx: fix possible NULL pointer dereference in wfx_set_mfp_ap()\n\nSince 'ieee80211_beacon_get()' can return NULL, 'wfx_set_mfp_ap()'\nshould check the return value before examining skb data. So convert\nthe latter to return an appropriate error code and propagate it to\nreturn from 'wfx_start_ap()' as well. Compile tested only.(CVE-2023-52593)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\njfs: fix slab-out-of-bounds Read in dtSearch\n\nCurrently while searching for current page in the sorted entry table\nof the page there is a out of bound access. Added a bound check to fix\nthe error.\n\nDave:\nSet return code to -EIO(CVE-2023-52602)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nUBSAN: array-index-out-of-bounds in dtSplitRoot\n\nSyzkaller reported the following issue:\n\noop0: detected capacity change from 0 to 32768\n\nUBSAN: array-index-out-of-bounds in fs/jfs/jfs_dtree.c:1971:9\nindex -2 is out of range for type 'struct dtslot [128]'\nCPU: 0 PID: 3613 Comm: syz-executor270 Not tainted 6.0.0-syzkaller-09423-g493ffd6605b2 #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1b1/0x28e lib/dump_stack.c:106\n ubsan_epilogue lib/ubsan.c:151 [inline]\n __ubsan_handle_out_of_bounds+0xdb/0x130 lib/ubsan.c:283\n dtSplitRoot+0x8d8/0x1900 fs/jfs/jfs_dtree.c:1971\n dtSplitUp fs/jfs/jfs_dtree.c:985 [inline]\n dtInsert+0x1189/0x6b80 fs/jfs/jfs_dtree.c:863\n jfs_mkdir+0x757/0xb00 fs/jfs/namei.c:270\n vfs_mkdir+0x3b3/0x590 fs/namei.c:4013\n do_mkdirat+0x279/0x550 fs/namei.c:4038\n __do_sys_mkdirat fs/namei.c:4053 [inline]\n __se_sys_mkdirat fs/namei.c:4051 [inline]\n __x64_sys_mkdirat+0x85/0x90 fs/namei.c:4051\n do_syscall_x64 arch/x86/entry/common.c:50 [inline]\n do_syscall_64+0x3d/0xb0 arch/x86/entry/common.c:80\n entry_SYSCALL_64_after_hwframe+0x63/0xcd\nRIP: 0033:0x7fcdc0113fd9\nCode: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 \u003c48\u003e 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff f7 d8 64 89 01 48\nRSP: 002b:00007ffeb8bc67d8 EFLAGS: 00000246 ORIG_RAX: 0000000000000102\nRAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007fcdc0113fd9\nRDX: 0000000000000000 RSI: 0000000020000340 RDI: 0000000000000003\nRBP: 00007fcdc00d37a0 R08: 0000000000000000 R09: 00007fcdc00d37a0\nR10: 00005555559a72c0 R11: 0000000000000246 R12: 00000000f8008000\nR13: 0000000000000000 R14: 00083878000000f8 R15: 0000000000000000\n \u003c/TASK\u003e\n\nThe issue is caused when the value of fsi becomes less than -1.\nThe check to break the loop when fsi value becomes -1 is present\nbut syzbot was able to produce value less than -1 which cause the error.\nThis patch simply add the change for the values less than 0.\n\nThe patch is tested via syzbot.(CVE-2023-52603)\n\nIn the Linux kernel, the following vulnerability has been resolved:\n\nFS:JFS:UBSAN:array-index-out-of-bounds in dbAdjTree\n\nSyzkaller reported the following issue:\n\nUBSAN: array-index-out-of-bounds in fs/jfs/jfs_dmap.c:2867:6\nindex 196694 is out of range for type 's8[1365]' (aka 'signed char[1365]')\nCPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106\n ubsan_epilogue lib/ubsan.c:217 [inline]\n __ubsan_handle_out_of_bounds+0x11c/0x150 lib/ubsan.c:348\n dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867\n dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834\n dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331\n dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]\n dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402\n txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534\n txUpdateMap+0x342/0x9e0\n txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]\n jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732\n kthread+0x2d3/0x370 kernel/kthread.c:388\n ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147\n ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304\n \u003c/TASK\u003e\n================================================================================\nKernel panic - not syncing: UBSAN: panic_on_warn set ...\nCPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106\n panic+0x30f/0x770 kernel/panic.c:340\n check_panic_on_warn+0x82/0xa0 kernel/panic.c:236\n ubsan_epilogue lib/ubsan.c:223 [inline]\n __ubsan_handle_out_of_bounds+0x13c/0x150 lib/ubsan.c:348\n dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867\n dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834\n dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331\n dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]\n dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402\n txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534\n txUpdateMap+0x342/0x9e0\n txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]\n jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732\n kthread+0x2d3/0x370 kernel/kthread.c:388\n ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147\n ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304\n \u003c/TASK\u003e\nKernel Offset: disabled\nRebooting in 86400 seconds..\n\nThe issue is caused when the value of lp becomes greater than\nCTLTREESIZE which is the max size of stree. Adding a simple check\nsolves this issue.\n\nDave:\nAs the function returns a void, good error handling\nwould require a more intrusive code reorganization, so I modified\nOsama's patch at use WARN_ON_ONCE for lack of a cleaner option.\n\nThe patch is tested via syzbot.(CVE-2023-52604)",
+      "Title": "Description",
+      "Type": "General"
+    },
+    {
+      "Text": "An update for kernel is now available for openEuler-22.03-LTS-SP2.\n\nopenEuler Security has rated this update as having a security impact of high. A Common Vunlnerability Scoring System(CVSS)base score,which gives a detailed severity rating, is available for each vulnerability from the CVElink(s) in the References section.",
+      "Title": "Topic",
+      "Type": "General"
+    },
+    {
+      "Text": "High",
+      "Title": "Severity",
+      "Type": "General"
+    },
+    {
+      "Text": "kernel",
+      "Title": "Affected Component",
+      "Type": "General"
+    }
+  ],
+  "ProductTree": {
+    "Branches": [
+      {
+        "Type": "Product Name",
+        "Name": "openEuler",
+        "Productions": [
+          {
+            "ProductID": "openEuler-22.03-LTS-SP2",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "openEuler-22.03-LTS-SP2"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "aarch64",
+        "Productions": [
+          {
+            "ProductID": "perf-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "perf-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "perf-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-tools-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-tools-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-headers-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-headers-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-perf-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "python3-perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-tools-devel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-devel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "python3-perf-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "python3-perf-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-debuginfo-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-debugsource-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-debugsource-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-source-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-source-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          },
+          {
+            "ProductID": "kernel-devel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-devel-5.10.0-153.48.0.126.oe2203sp2.aarch64.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "src",
+        "Productions": [
+          {
+            "ProductID": "kernel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-5.10.0-153.48.0.126.oe2203sp2.src.rpm"
+          }
+        ]
+      },
+      {
+        "Type": "Package Arch",
+        "Name": "x86_64",
+        "Productions": [
+          {
+            "ProductID": "kernel-tools-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-debugsource-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-debugsource-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-perf-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "python3-perf-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-source-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-source-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "python3-perf-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "python3-perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-headers-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-headers-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-tools-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-tools-devel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-tools-devel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "perf-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "perf-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-devel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-devel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "kernel-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "kernel-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          },
+          {
+            "ProductID": "perf-debuginfo-5.10.0-153.48.0.126",
+            "CPE": "cpe:/a:openEuler:openEuler:22.03-LTS-SP2",
+            "Text": "perf-debuginfo-5.10.0-153.48.0.126.oe2203sp2.x86_64.rpm"
+          }
+        ]
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.openeuler.org/en/security/safety-bulletin/detail.html?id=openEuler-SA-2024-1349"
+    },
+    {
+      "URL": "https://www.openeuler.org/en/security/cve/detail.html?id=CVE-2023-52604"
+    },
+    {
+      "URL": "https://nvd.nist.gov/vuln/detail/CVE-2023-52604"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2021-47014",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nnet/sched: act_ct: fix wild memory access when clearing fragments\n\nwhile testing re-assembly/re-fragmentation using act_ct, it's possible to\nobserve a crash like the following one:\n\n KASAN: maybe wild-memory-access in range [0x0001000000000448-0x000100000000044f]\n CPU: 50 PID: 0 Comm: swapper/50 Tainted: G S                5.12.0-rc7+ #424\n Hardware name: Dell Inc. PowerEdge R730/072T6D, BIOS 2.4.3 01/17/2017\n RIP: 0010:inet_frag_rbtree_purge+0x50/0xc0\n Code: 00 fc ff df 48 89 c3 31 ed 48 89 df e8 a9 7a 38 ff 4c 89 fe 48 89 df 49 89 c6 e8 5b 3a 38 ff 48 8d 7b 40 48 89 f8 48 c1 e8 03 \u003c42\u003e 80 3c 20 00 75 59 48 8d bb d0 00 00 00 4c 8b 6b 40 48 89 f8 48\n RSP: 0018:ffff888c31449db8 EFLAGS: 00010203\n RAX: 0000200000000089 RBX: 000100000000040e RCX: ffffffff989eb960\n RDX: 0000000000000140 RSI: ffffffff97cfb977 RDI: 000100000000044e\n RBP: 0000000000000900 R08: 0000000000000000 R09: ffffed1186289350\n R10: 0000000000000003 R11: ffffed1186289350 R12: dffffc0000000000\n R13: 000100000000040e R14: 0000000000000000 R15: ffff888155e02160\n FS:  0000000000000000(0000) GS:ffff888c31440000(0000) knlGS:0000000000000000\n CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033\n CR2: 00005600cb70a5b8 CR3: 0000000a2c014005 CR4: 00000000003706e0\n DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000\n DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400\n Call Trace:\n  \u003cIRQ\u003e\n  inet_frag_destroy+0xa9/0x150\n  call_timer_fn+0x2d/0x180\n  run_timer_softirq+0x4fe/0xe70\n  __do_softirq+0x197/0x5a0\n  irq_exit_rcu+0x1de/0x200\n  sysvec_apic_timer_interrupt+0x6b/0x80\n  \u003c/IRQ\u003e\n\nwhen act_ct temporarily stores an IP fragment, restoring the skb qdisc cb\nresults in putting random data in FRAG_CB(), and this causes those \"wild\"\nmemory accesses later, when the rbtree is purged. Never overwrite the skb\ncb in case tcf_ct_handle_fragments() returns -EINPROGRESS.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.1",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2021-47036",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nudp: skip L4 aggregation for UDP tunnel packets\n\nIf NETIF_F_GRO_FRAGLIST or NETIF_F_GRO_UDP_FWD are enabled, and there\nare UDP tunnels available in the system, udp_gro_receive() could end-up\ndoing L4 aggregation (either SKB_GSO_UDP_L4 or SKB_GSO_FRAGLIST) at\nthe outer UDP tunnel level for packets effectively carrying and UDP\ntunnel header.\n\nThat could cause inner protocol corruption. If e.g. the relevant\npackets carry a vxlan header, different vxlan ids will be ignored/\naggregated to the same GSO packet. Inner headers will be ignored, too,\nso that e.g. TCP over vxlan push packets will be held in the GRO\nengine till the next flush, etc.\n\nJust skip the SKB_GSO_UDP_L4 and SKB_GSO_FRAGLIST code path if the\ncurrent packet could land in a UDP tunnel, and let udp_gro_receive()\ndo GRO via udp_sk(sk)-\u003egro_receive.\n\nThe check implemented in this patch is broader than what is strictly\nneeded, as the existing UDP tunnel could be e.g. configured on top of\na different device: we could end-up skipping GRO at-all for some packets.\n\nAnyhow, that is a very thin corner case and covering it will add quite\na bit of complexity.\n\nv1 -\u003e v2:\n - hopefully clarify the commit message",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "5.3",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52445",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nmedia: pvrusb2: fix use after free on context disconnection\n\nUpon module load, a kthread is created targeting the\npvr2_context_thread_func function, which may call pvr2_context_destroy\nand thus call kfree() on the context object. However, that might happen\nbefore the usb hub_event handler is able to notify the driver. This\npatch adds a sanity check before the invalid read reported by syzbot,\nwithin the context disconnection call stack.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.8",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52458",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nblock: add check that partition length needs to be aligned with block size\n\nBefore calling add partition or resize partition, there is no check\non whether the length is aligned with the logical block size.\nIf the logical block size of the disk is larger than 512 bytes,\nthen the partition size maybe not the multiple of the logical block size,\nand when the last sector is read, bio_truncate() will adjust the bio size,\nresulting in an IO error if the size of the read command is smaller than\nthe logical block size.If integrity data is supported, this will also\nresult in a null pointer dereference when calling bio_integrity_free.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "4.2",
+        "Vector": "AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52528",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nnet: usb: smsc75xx: Fix uninit-value access in __smsc75xx_read_reg\n\nsyzbot reported the following uninit-value access issue:\n\n=====================================================\nBUG: KMSAN: uninit-value in smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]\nBUG: KMSAN: uninit-value in smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482\nCPU: 0 PID: 8696 Comm: kworker/0:3 Not tainted 5.8.0-rc5-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011\nWorkqueue: usb_hub_wq hub_event\nCall Trace:\n __dump_stack lib/dump_stack.c:77 [inline]\n dump_stack+0x21c/0x280 lib/dump_stack.c:118\n kmsan_report+0xf7/0x1e0 mm/kmsan/kmsan_report.c:121\n __msan_warning+0x58/0xa0 mm/kmsan/kmsan_instr.c:215\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:975 [inline]\n smsc75xx_bind+0x5c9/0x11e0 drivers/net/usb/smsc75xx.c:1482\n usbnet_probe+0x1152/0x3f90 drivers/net/usb/usbnet.c:1737\n usb_probe_interface+0xece/0x1550 drivers/usb/core/driver.c:374\n really_probe+0xf20/0x20b0 drivers/base/dd.c:529\n driver_probe_device+0x293/0x390 drivers/base/dd.c:701\n __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807\n bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431\n __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873\n device_initial_probe+0x4a/0x60 drivers/base/dd.c:920\n bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491\n device_add+0x3b0e/0x40d0 drivers/base/core.c:2680\n usb_set_configuration+0x380f/0x3f10 drivers/usb/core/message.c:2032\n usb_generic_driver_probe+0x138/0x300 drivers/usb/core/generic.c:241\n usb_probe_device+0x311/0x490 drivers/usb/core/driver.c:272\n really_probe+0xf20/0x20b0 drivers/base/dd.c:529\n driver_probe_device+0x293/0x390 drivers/base/dd.c:701\n __device_attach_driver+0x63f/0x830 drivers/base/dd.c:807\n bus_for_each_drv+0x2ca/0x3f0 drivers/base/bus.c:431\n __device_attach+0x4e2/0x7f0 drivers/base/dd.c:873\n device_initial_probe+0x4a/0x60 drivers/base/dd.c:920\n bus_probe_device+0x177/0x3d0 drivers/base/bus.c:491\n device_add+0x3b0e/0x40d0 drivers/base/core.c:2680\n usb_new_device+0x1bd4/0x2a30 drivers/usb/core/hub.c:2554\n hub_port_connect drivers/usb/core/hub.c:5208 [inline]\n hub_port_connect_change drivers/usb/core/hub.c:5348 [inline]\n port_event drivers/usb/core/hub.c:5494 [inline]\n hub_event+0x5e7b/0x8a70 drivers/usb/core/hub.c:5576\n process_one_work+0x1688/0x2140 kernel/workqueue.c:2269\n worker_thread+0x10bc/0x2730 kernel/workqueue.c:2415\n kthread+0x551/0x590 kernel/kthread.c:292\n ret_from_fork+0x1f/0x30 arch/x86/entry/entry_64.S:293\n\nLocal variable ----buf.i87@smsc75xx_bind created at:\n __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]\n smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482\n __smsc75xx_read_reg drivers/net/usb/smsc75xx.c:83 [inline]\n smsc75xx_wait_ready drivers/net/usb/smsc75xx.c:968 [inline]\n smsc75xx_bind+0x485/0x11e0 drivers/net/usb/smsc75xx.c:1482\n\nThis issue is caused because usbnet_read_cmd() reads less bytes than requested\n(zero byte in the reproducer). In this case, 'buf' is not properly filled.\n\nThis patch fixes the issue by returning -ENODATA if usbnet_read_cmd() reads\nless bytes than requested.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "4.4",
+        "Vector": "AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52593",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nwifi: wfx: fix possible NULL pointer dereference in wfx_set_mfp_ap()\n\nSince 'ieee80211_beacon_get()' can return NULL, 'wfx_set_mfp_ap()'\nshould check the return value before examining skb data. So convert\nthe latter to return an appropriate error code and propagate it to\nreturn from 'wfx_start_ap()' as well. Compile tested only.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "Medium"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "4.4",
+        "Vector": "AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52602",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\njfs: fix slab-out-of-bounds Read in dtSearch\n\nCurrently while searching for current page in the sorted entry table\nof the page there is a out of bound access. Added a bound check to fix\nthe error.\n\nDave:\nSet return code to -EIO",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.1",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52603",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nUBSAN: array-index-out-of-bounds in dtSplitRoot\n\nSyzkaller reported the following issue:\n\noop0: detected capacity change from 0 to 32768\n\nUBSAN: array-index-out-of-bounds in fs/jfs/jfs_dtree.c:1971:9\nindex -2 is out of range for type 'struct dtslot [128]'\nCPU: 0 PID: 3613 Comm: syz-executor270 Not tainted 6.0.0-syzkaller-09423-g493ffd6605b2 #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/22/2022\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1b1/0x28e lib/dump_stack.c:106\n ubsan_epilogue lib/ubsan.c:151 [inline]\n __ubsan_handle_out_of_bounds+0xdb/0x130 lib/ubsan.c:283\n dtSplitRoot+0x8d8/0x1900 fs/jfs/jfs_dtree.c:1971\n dtSplitUp fs/jfs/jfs_dtree.c:985 [inline]\n dtInsert+0x1189/0x6b80 fs/jfs/jfs_dtree.c:863\n jfs_mkdir+0x757/0xb00 fs/jfs/namei.c:270\n vfs_mkdir+0x3b3/0x590 fs/namei.c:4013\n do_mkdirat+0x279/0x550 fs/namei.c:4038\n __do_sys_mkdirat fs/namei.c:4053 [inline]\n __se_sys_mkdirat fs/namei.c:4051 [inline]\n __x64_sys_mkdirat+0x85/0x90 fs/namei.c:4051\n do_syscall_x64 arch/x86/entry/common.c:50 [inline]\n do_syscall_64+0x3d/0xb0 arch/x86/entry/common.c:80\n entry_SYSCALL_64_after_hwframe+0x63/0xcd\nRIP: 0033:0x7fcdc0113fd9\nCode: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 \u003c48\u003e 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff f7 d8 64 89 01 48\nRSP: 002b:00007ffeb8bc67d8 EFLAGS: 00000246 ORIG_RAX: 0000000000000102\nRAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007fcdc0113fd9\nRDX: 0000000000000000 RSI: 0000000020000340 RDI: 0000000000000003\nRBP: 00007fcdc00d37a0 R08: 0000000000000000 R09: 00007fcdc00d37a0\nR10: 00005555559a72c0 R11: 0000000000000246 R12: 00000000f8008000\nR13: 0000000000000000 R14: 00083878000000f8 R15: 0000000000000000\n \u003c/TASK\u003e\n\nThe issue is caused when the value of fsi becomes less than -1.\nThe check to break the loop when fsi value becomes -1 is present\nbut syzbot was able to produce value less than -1 which cause the error.\nThis patch simply add the change for the values less than 0.\n\nThe patch is tested via syzbot.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.1",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H"
+      }
+    },
+    {
+      "CVE": "CVE-2023-52604",
+      "Description": "In the Linux kernel, the following vulnerability has been resolved:\n\nFS:JFS:UBSAN:array-index-out-of-bounds in dbAdjTree\n\nSyzkaller reported the following issue:\n\nUBSAN: array-index-out-of-bounds in fs/jfs/jfs_dmap.c:2867:6\nindex 196694 is out of range for type 's8[1365]' (aka 'signed char[1365]')\nCPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106\n ubsan_epilogue lib/ubsan.c:217 [inline]\n __ubsan_handle_out_of_bounds+0x11c/0x150 lib/ubsan.c:348\n dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867\n dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834\n dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331\n dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]\n dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402\n txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534\n txUpdateMap+0x342/0x9e0\n txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]\n jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732\n kthread+0x2d3/0x370 kernel/kthread.c:388\n ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147\n ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304\n \u003c/TASK\u003e\n================================================================================\nKernel panic - not syncing: UBSAN: panic_on_warn set ...\nCPU: 1 PID: 109 Comm: jfsCommit Not tainted 6.6.0-rc3-syzkaller #0\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 08/04/2023\nCall Trace:\n \u003cTASK\u003e\n __dump_stack lib/dump_stack.c:88 [inline]\n dump_stack_lvl+0x1e7/0x2d0 lib/dump_stack.c:106\n panic+0x30f/0x770 kernel/panic.c:340\n check_panic_on_warn+0x82/0xa0 kernel/panic.c:236\n ubsan_epilogue lib/ubsan.c:223 [inline]\n __ubsan_handle_out_of_bounds+0x13c/0x150 lib/ubsan.c:348\n dbAdjTree+0x474/0x4f0 fs/jfs/jfs_dmap.c:2867\n dbJoin+0x210/0x2d0 fs/jfs/jfs_dmap.c:2834\n dbFreeBits+0x4eb/0xda0 fs/jfs/jfs_dmap.c:2331\n dbFreeDmap fs/jfs/jfs_dmap.c:2080 [inline]\n dbFree+0x343/0x650 fs/jfs/jfs_dmap.c:402\n txFreeMap+0x798/0xd50 fs/jfs/jfs_txnmgr.c:2534\n txUpdateMap+0x342/0x9e0\n txLazyCommit fs/jfs/jfs_txnmgr.c:2664 [inline]\n jfs_lazycommit+0x47a/0xb70 fs/jfs/jfs_txnmgr.c:2732\n kthread+0x2d3/0x370 kernel/kthread.c:388\n ret_from_fork+0x48/0x80 arch/x86/kernel/process.c:147\n ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:304\n \u003c/TASK\u003e\nKernel Offset: disabled\nRebooting in 86400 seconds..\n\nThe issue is caused when the value of lp becomes greater than\nCTLTREESIZE which is the max size of stree. Adding a simple check\nsolves this issue.\n\nDave:\nAs the function returns a void, good error handling\nwould require a more intrusive code reorganization, so I modified\nOsama's patch at use WARN_ON_ONCE for lack of a cleaner option.\n\nThe patch is tested via syzbot.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "High"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openEuler-22.03-LTS-SP2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "7.8",
+        "Vector": "AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      }
+    }
+  ]
+}

--- a/openeuler/testdata/index.txt
+++ b/openeuler/testdata/index.txt
@@ -1,0 +1,13 @@
+2021/cvrf-openEuler-SA-2021-1033.xml
+2021/cvrf-openEuler-SA-2021-1202.xml
+2021/cvrf-openEuler-SA-2021-1480.xml
+2022/cvrf-openEuler-SA-2022-1485.xml
+2022/cvrf-openEuler-SA-2022-1580.xml
+2022/cvrf-openEuler-SA-2022-1704.xml
+2023/cvrf-openEuler-SA-2023-1006.xml
+2023/cvrf-openEuler-SA-2023-1010.xml
+2023/cvrf-openEuler-SA-2023-1374.xml
+2024/cvrf-openEuler-SA-2024-1151.xml
+2024/cvrf-openEuler-SA-2024-1295.xml
+2024/cvrf-openEuler-SA-2024-1349.xml
+2022/cvrf-openEuler-SA-2022-1693.xml

--- a/openeuler/testdata/invalid-index.txt
+++ b/openeuler/testdata/invalid-index.txt
@@ -1,0 +1,1 @@
+2021/cvrf-openEuler-SA-2021-1202.xml

--- a/openeuler/testdata/invalid.txt
+++ b/openeuler/testdata/invalid.txt
@@ -1,0 +1,1 @@
+openEuler

--- a/openeuler/types.go
+++ b/openeuler/types.go
@@ -1,0 +1,84 @@
+package openeuler
+
+type Cvrf struct {
+	Title           string           `xml:"DocumentTitle"`
+	Tracking        DocumentTracking `xml:"DocumentTracking"`
+	Notes           []DocumentNote   `xml:"DocumentNotes>Note"`
+	ProductTree     ProductTree      `xml:"ProductTree"`
+	References      []Reference      `xml:"DocumentReferences>Reference"`
+	Vulnerabilities []Vulnerability  `xml:"Vulnerability"`
+}
+
+type DocumentTracking struct {
+	ID                 string     `xml:"Identification>ID"`
+	Status             string     `xml:"Status"`
+	Version            string     `xml:"Version"`
+	InitialReleaseDate string     `xml:"InitialReleaseDate"`
+	CurrentReleaseDate string     `xml:"CurrentReleaseDate"`
+	RevisionHistory    []Revision `xml:"RevisionHistory>Revision"`
+}
+
+type DocumentNote struct {
+	Text  string `xml:",chardata"`
+	Title string `xml:"Title,attr"`
+	Type  string `xml:"Type,attr"`
+}
+
+type ProductTree struct {
+	Branches []Branch `xml:"Branch"`
+}
+
+type Branch struct {
+	Type        string       `xml:"Type,attr"`
+	Name        string       `xml:"Name,attr"`
+	Productions []Production `xml:"FullProductName"`
+}
+
+type Production struct {
+	ProductID string `xml:"ProductID,attr"`
+	CPE       string `xml:"CPE,attr"`
+	Text      string `xml:",chardata"`
+}
+
+type Revision struct {
+	Number      string `xml:"Number"`
+	Date        string `xml:"Date"`
+	Description string `xml:"Description"`
+}
+
+type Vulnerability struct {
+	CVE             string   `xml:"CVE"`
+	Description     string   `xml:"Notes>Note"`
+	Threats         []Threat `xml:"Threats>Threat"`
+	ProductStatuses []Status `xml:"ProductStatuses>Status"`
+	CVSSScoreSets   ScoreSet `xml:"CVSSScoreSets>ScoreSet" json:",omitempty"`
+}
+
+type Reference struct {
+	URL string `xml:"URL"`
+}
+
+type Threat struct {
+	Type     string `xml:"Type,attr"`
+	Severity string `xml:"Description"`
+}
+
+type Status struct {
+	Type      string   `xml:"Type,attr"`
+	ProductID []string `xml:"ProductID"`
+}
+
+type ScoreSet struct {
+	BaseScore string `xml:"BaseScore" json:",omitempty"`
+	Vector    string `xml:"Vector" json:",omitempty"`
+}
+
+type Package struct {
+	Name         string
+	FixedVersion string
+}
+
+type AffectedPackage struct {
+	Package Package
+	OSVer   string
+}


### PR DESCRIPTION
### Description

## What's openEuler?
openEuler is an open source, free Linux distribution platform. The platform provides an open community for global developers to build an open, diversified, and architecture-inclusive software ecosystem. openEuler is also an innovative platform that
encourages everyone to propose new ideas, explore new approaches, and practice new solutions.

Learn more, please visit https://www.openeuler.org/en/

## Trivy does not support openEuler
We can see that the operating systems currently supported by trivy for security detection does not include openEuler(see https://aquasecurity.github.io/trivy/v0.50/docs/coverage/os/).  

![image](https://github.com/aquasecurity/trivy/assets/135617475/1ff278ab-c29d-4578-82d2-ecad2613f90c)

## To support openEuler
Now, openEuler has 2,345,659 users, 18,072 contributors and 1,501 organization members(see https://datastat.openeuler.org/en/overview). It is necessary to support such a very mature open source operating system.

## Discussion
Our discussion is here https://github.com/aquasecurity/trivy/discussions/6400



