### PR TITLE
Add support for Anolis OS

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -102,3 +102,7 @@ jobs:
     - if: always()
       name: openEuler CVE
       run: ./scripts/update.sh openeuler "openEuler CVE Data"
+
+    - if: always()
+      name: Anolis OVAL 
+      run: ./scripts/update.sh anolis "Anolis OVAL Data"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/aquasecurity/vuln-list/
 $ vuln-list-update -h
 Usage of vuln-list-update:
   -target string
-        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler)
+        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler,anolis)
   -target-branch string
     	alternative repository branch (only glad)
   -target-uri string

--- a/anolis/anolis.go
+++ b/anolis/anolis.go
@@ -1,0 +1,125 @@
+package anolis
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	pb "github.com/cheggaaa/pb/v3"
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+const (
+	anolisDir = "anolis"
+	urlFormat = "https://anas.openanolis.cn/api/data/OVAL/anolis-%s.oval.xml"
+	retry     = 5
+)
+
+var (
+	AnolisOvalVersion = []string{"7", "7_els", "8", "23"}
+)
+var (
+	ErrInvalidANSAID = xerrors.New("invalid ANSA ID")
+)
+
+type Config struct {
+	VulnListDir string
+	URLs        map[string]string
+	AppFs       afero.Fs
+	Retry       int
+}
+
+func NewConfig() Config {
+	urls := map[string]string{}
+	for _, version := range AnolisOvalVersion {
+		urls[version] = fmt.Sprintf(urlFormat, version)
+	}
+	return Config{
+		VulnListDir: utils.VulnListDir(),
+		URLs:        urls,
+		AppFs:       afero.NewOsFs(),
+		Retry:       retry,
+	}
+}
+
+func (c *Config) Update() error {
+	for version, url := range c.URLs {
+		if version == "7_els" {
+			version = "7"
+		}
+		log.Printf("Fetching Anolis OVAL data from %s...\n", url)
+
+		// Fetch the XML file from the URL
+		res, err := utils.FetchURL(url, "", c.Retry)
+		if err != nil {
+			return xerrors.Errorf("failed to fetch Anolis OVAL: %w", err)
+		}
+
+		var ov Oval
+		err = xml.NewDecoder(bytes.NewReader(res)).Decode(&ov)
+		if err != nil {
+			return xerrors.Errorf("failed to decode Anolis OVAL XML: %w", err)
+		}
+
+		dir := filepath.Join(c.VulnListDir, anolisDir, version)
+		bar := pb.StartNew(len(ov.Definitions))
+
+		for _, def := range ov.Definitions {
+			def.Metadata.Title = strings.TrimSpace(def.Metadata.Title)
+			def.Metadata.Description = strings.TrimSpace(def.Metadata.Description)
+
+			var ansaID string
+			for _, ref := range def.Metadata.References {
+				if strings.HasPrefix(ref.RefID, "ANSA") {
+					ansaID = strings.TrimSpace(ref.RefID)
+					break
+				}
+			}
+
+			if ansaID == "" {
+				log.Printf("Invalid ANSA ID: %s\n", ansaID)
+				continue
+			}
+
+			if err = c.SaveANSAPerYear(dir, ansaID, def); err != nil {
+				if err == ErrInvalidANSAID {
+					log.Printf("Invalid ANSA ID: %s\n", ansaID)
+					continue
+				}
+				return xerrors.Errorf("failed to save ANSA per year: %w", err)
+			}
+			bar.Increment()
+		}
+		bar.Finish()
+	}
+
+	return nil
+}
+
+func (c Config) SaveANSAPerYear(dirName string, ansaID string, data interface{}) error {
+	s := strings.Split(ansaID, ":")
+	if len(s) < 2 {
+		return ErrInvalidANSAID
+	}
+
+	year := strings.Split(s[0], "-")[1] // Extract the year part from "ANSA-2024"
+	yearDir := filepath.Join(dirName, year)
+
+	if err := c.AppFs.MkdirAll(yearDir, os.ModePerm); err != nil {
+		return xerrors.Errorf("failed to create directory: %w", err)
+	}
+	jsonFileName := fmt.Sprintf("%s.json", ansaID)
+
+	if err := utils.WriteJSON(c.AppFs, yearDir, jsonFileName, data); err != nil {
+		return xerrors.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}

--- a/anolis/anolis_test.go
+++ b/anolis/anolis_test.go
@@ -1,0 +1,107 @@
+package anolis_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/vuln-list-update/anolis"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_Update(t *testing.T) {
+	testCases := []struct {
+		name             string
+		appFs            afero.Fs
+		xmlFileNames     map[string]string
+		goldenFiles      map[string]string
+		expectedErrorMsg string
+	}{
+		{
+			name:  "happy path test",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/anolis/anolis-7.oval.xml": "testdata/happy/anolis-7_els.oval.xml",
+			},
+			goldenFiles: map[string]string{
+				"/tmp/anolis/7/2024/ANSA-2024-0788.json": "testdata/golden/7_els/2024/ANSA-2024:0784.json/ANSA-2024-0788.json",
+			},
+		},
+		{
+			name:  "sad path test",
+			appFs: afero.NewMemMapFs(),
+			xmlFileNames: map[string]string{
+				"/anolis/anolis-7.oval.xml": "testdata/sad/anolis-7_els.oval.xml",
+			},
+			goldenFiles:      map[string]string{},
+			expectedErrorMsg: "failed to decode Anolis OVAL XML",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				filePath, ok := tc.xmlFileNames[r.URL.Path]
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				b, err := os.ReadFile(filePath)
+				assert.NoError(t, err, tc.name)
+				_, err = w.Write(b)
+				assert.NoError(t, err, tc.name)
+			}))
+			defer ts.Close()
+
+			urls := map[string]string{
+				"7": ts.URL + "/anolis/anolis-7.oval.xml",
+			}
+
+			c := anolis.Config{
+				VulnListDir: "/tmp",
+				URLs:        urls,
+				AppFs:       tc.appFs,
+				Retry:       0,
+			}
+
+			err := c.Update()
+
+			if tc.expectedErrorMsg != "" {
+				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
+				return
+			} else {
+				assert.NoError(t, err, tc.name)
+			}
+
+			// Validate generated files
+			err = afero.Walk(c.AppFs, "/", func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+
+				actual, err := afero.ReadFile(c.AppFs, path)
+				assert.NoError(t, err, tc.name)
+
+				goldenPath, ok := tc.goldenFiles[path]
+				if !ok {
+					return nil
+				}
+
+				expected, err := os.ReadFile(goldenPath)
+				assert.NoError(t, err, tc.name)
+
+				// Only print the diff if the test fails
+				assert.Equal(t, expected, actual, tc.name)
+
+				return nil
+			})
+
+			assert.NoError(t, err, tc.name)
+		})
+	}
+}

--- a/anolis/testdata/golden/7_els/2024/ANSA-2024:0784.json
+++ b/anolis/testdata/golden/7_els/2024/ANSA-2024:0784.json
@@ -1,0 +1,97 @@
+{
+  "ID": "oval:cn.openanolis:def:20240784",
+  "Version": "1",
+  "Class": "patch",
+  "Metadata": {
+    "Title": "ANSA-2024:0784: pki-core security update (Important)",
+    "Affected": {
+      "Family": "unix",
+      "Platform": [
+        "Anolis OS 7"
+      ]
+    },
+    "References": [
+      {
+        "RefID": "ANSA-2024:0784",
+        "RefURL": "https://anas.openanolis.cn/errata/detail/ANSA-2024:0784",
+        "Source": "ANSA"
+      }
+    ],
+    "Description": "Package updates are available for Anolis 7 that fix the following vulnerabilities:\n\nCVE-2023-4727:\nA flaw was found in dogtag-pki and pki-core. The token authentication scheme can be bypassed with a LDAP injection. By passing the query string parameter sessionID=*, an attacker can authenticate with an existing session saved in the LDAP directory server, which may lead to escalation of privilege.",
+    "Advisory": {
+      "Severity": "Important",
+      "Issued": {
+        "Date": "2024-08-08"
+      },
+      "Updated": {
+        "Date": "2024-08-13"
+      },
+      "Cves": [
+        {
+          "ID": "CVE-2023-4727",
+          "CVSS3": "7.5/CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "Impact": "Important",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2023-4727",
+          "CWE": "CWE-305",
+          "Public": "20240725"
+        }
+      ],
+      "AffectedCpeList": [
+        "cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* "
+      ]
+    }
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": null,
+        "Criterions": [
+          {
+            "Comment": "pki-symkey is earlier than 0:symkey-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784001"
+          },
+          {
+            "Comment": "pki-tools is earlier than 0:tools-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784002"
+          },
+          {
+            "Comment": "pki-core is earlier than 0:core-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784003"
+          },
+          {
+            "Comment": "pki-base is earlier than 0:base-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784004"
+          },
+          {
+            "Comment": "pki-base-java is earlier than 0:base-java-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784005"
+          },
+          {
+            "Comment": "pki-ca is earlier than 0:ca-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784006"
+          },
+          {
+            "Comment": "pki-javadoc is earlier than 0:javadoc-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784007"
+          },
+          {
+            "Comment": "pki-kra is earlier than 0:kra-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784008"
+          },
+          {
+            "Comment": "pki-server is earlier than 0:server-10.5.18-32.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240784009"
+          }
+        ]
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Anolis OS 7 is installed",
+        "TestRef": "oval:cn.openanolis:tst:1"
+      }
+    ]
+  }
+}

--- a/anolis/testdata/golden/7_els/2024/ANSA-2024:0786.json
+++ b/anolis/testdata/golden/7_els/2024/ANSA-2024:0786.json
@@ -1,0 +1,81 @@
+{
+  "ID": "oval:cn.openanolis:def:20240786",
+  "Version": "1",
+  "Class": "patch",
+  "Metadata": {
+    "Title": "ANSA-2024:0786: firefox security update (Important)",
+    "Affected": {
+      "Family": "unix",
+      "Platform": [
+        "Anolis OS 7"
+      ]
+    },
+    "References": [
+      {
+        "RefID": "ANSA-2024:0786",
+        "RefURL": "https://anas.openanolis.cn/errata/detail/ANSA-2024:0786",
+        "Source": "ANSA"
+      }
+    ],
+    "Description": "Package updates are available for Anolis 7 that fix the following vulnerabilities:\n\nCVE-2024-6601:\nA race condition could lead to a cross-origin container obtaining permissions of the top-level origin. This vulnerability affects Firefox \u003c 128, Firefox ESR \u003c 115.13, Thunderbird \u003c 115.13, and Thunderbird \u003c 128.\n\nCVE-2024-6603:\nIn an out-of-memory scenario an allocation could fail but free would have been called on the pointer afterwards leading to memory corruption. This vulnerability affects Firefox \u003c 128, Firefox ESR \u003c 115.13, Thunderbird \u003c 115.13, and Thunderbird \u003c 128.\n\nCVE-2024-6604:\nMemory safety bugs present in Firefox 127, Firefox ESR 115.12, and Thunderbird 115.12. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox \u003c 128, Firefox ESR \u003c 115.13, Thunderbird \u003c 115.13, and Thunderbird \u003c 128.",
+    "Advisory": {
+      "Severity": "Important",
+      "Issued": {
+        "Date": "2024-08-08"
+      },
+      "Updated": {
+        "Date": "2024-08-13"
+      },
+      "Cves": [
+        {
+          "ID": "CVE-2024-6601",
+          "CVSS3": "6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "Impact": "Moderate",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-6601",
+          "CWE": "CWE-281",
+          "Public": "20240723"
+        },
+        {
+          "ID": "CVE-2024-6603",
+          "CVSS3": "6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "Impact": "Moderate",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-6603",
+          "CWE": "CWE-119",
+          "Public": "20240723"
+        },
+        {
+          "ID": "CVE-2024-6604",
+          "CVSS3": "7.5/CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "Impact": "Important",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-6604",
+          "CWE": "CWE-120",
+          "Public": "20240723"
+        }
+      ],
+      "AffectedCpeList": [
+        "cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* "
+      ]
+    }
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": null,
+        "Criterions": [
+          {
+            "Comment": "firefox is earlier than 0:115.13.0-3.0.1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240786001"
+          }
+        ]
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Anolis OS 7 is installed",
+        "TestRef": "oval:cn.openanolis:tst:1"
+      }
+    ]
+  }
+}

--- a/anolis/testdata/golden/7_els/2024/ANSA-2024:0787.json
+++ b/anolis/testdata/golden/7_els/2024/ANSA-2024:0787.json
@@ -1,0 +1,69 @@
+{
+  "ID": "oval:cn.openanolis:def:20240787",
+  "Version": "1",
+  "Class": "patch",
+  "Metadata": {
+    "Title": "ANSA-2024:0787: libndp security update (Important)",
+    "Affected": {
+      "Family": "unix",
+      "Platform": [
+        "Anolis OS 7"
+      ]
+    },
+    "References": [
+      {
+        "RefID": "ANSA-2024:0787",
+        "RefURL": "https://anas.openanolis.cn/errata/detail/ANSA-2024:0787",
+        "Source": "ANSA"
+      }
+    ],
+    "Description": "Package updates are available for Anolis 7 that fix the following vulnerabilities:\n\nCVE-2024-5564:\nA vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.",
+    "Advisory": {
+      "Severity": "Important",
+      "Issued": {
+        "Date": "2024-08-08"
+      },
+      "Updated": {
+        "Date": "2024-08-13"
+      },
+      "Cves": [
+        {
+          "ID": "CVE-2024-5564",
+          "CVSS3": "8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "Impact": "Important",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-5564",
+          "CWE": "CWE-120",
+          "Public": "20240729"
+        }
+      ],
+      "AffectedCpeList": [
+        "cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* "
+      ]
+    }
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": null,
+        "Criterions": [
+          {
+            "Comment": "libndp is earlier than 0:1.2-10.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240787001"
+          },
+          {
+            "Comment": "libndp-devel is earlier than 0:devel-1.2-10.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240787002"
+          }
+        ]
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Anolis OS 7 is installed",
+        "TestRef": "oval:cn.openanolis:tst:1"
+      }
+    ]
+  }
+}

--- a/anolis/testdata/golden/7_els/2024/ANSA-2024:0788.json
+++ b/anolis/testdata/golden/7_els/2024/ANSA-2024:0788.json
@@ -1,0 +1,165 @@
+{
+  "ID": "oval:cn.openanolis:def:20240788",
+  "Version": "1",
+  "Class": "patch",
+  "Metadata": {
+    "Title": "ANSA-2024:0788: java-1.8.0-openjdk security update (Important)",
+    "Affected": {
+      "Family": "unix",
+      "Platform": [
+        "Anolis OS 7"
+      ]
+    },
+    "References": [
+      {
+        "RefID": "ANSA-2024:0788",
+        "RefURL": "https://anas.openanolis.cn/errata/detail/ANSA-2024:0788",
+        "Source": "ANSA"
+      }
+    ],
+    "Description": "Package updates are available for Anolis 7 that fix the following vulnerabilities:\n\nCVE-2024-21131:\nVulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 3.7 (Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N).\n\nCVE-2024-21138:\nVulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 3.7 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L).\n\nCVE-2024-21140:\nVulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized read access to a subset of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 4.8 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N).\n\nCVE-2024-21144:\nVulnerability in the Oracle Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Concurrency).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Oracle Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 3.7 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L).\n\nCVE-2024-21145:\nVulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: 2D).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized read access to a subset of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 4.8 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N).\n\nCVE-2024-21147:\nVulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 7.4 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N).",
+    "Advisory": {
+      "Severity": "Important",
+      "Issued": {
+        "Date": "2024-08-08"
+      },
+      "Updated": {
+        "Date": "2024-08-13"
+      },
+      "Cves": [
+        {
+          "ID": "CVE-2024-21131",
+          "CVSS3": "3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "Impact": "Low",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21131",
+          "CWE": "",
+          "Public": "20240808"
+        },
+        {
+          "ID": "CVE-2024-21138",
+          "CVSS3": "3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "Impact": "Low",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21138",
+          "CWE": "CWE-835",
+          "Public": "20240808"
+        },
+        {
+          "ID": "CVE-2024-21140",
+          "CVSS3": "4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "Impact": "Moderate",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21140",
+          "CWE": "",
+          "Public": "20240808"
+        },
+        {
+          "ID": "CVE-2024-21144",
+          "CVSS3": "3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "Impact": "Low",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21144",
+          "CWE": "CWE-20-\u003eCWE-400",
+          "Public": "20240808"
+        },
+        {
+          "ID": "CVE-2024-21145",
+          "CVSS3": "4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "Impact": "Moderate",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21145",
+          "CWE": "(CWE-125|CWE-787)",
+          "Public": "20240808"
+        },
+        {
+          "ID": "CVE-2024-21147",
+          "CVSS3": "7.4/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+          "Impact": "Important",
+          "Href": "https://anas.openanolis.cn/cves/detail/CVE-2024-21147",
+          "CWE": "",
+          "Public": "20240808"
+        }
+      ],
+      "AffectedCpeList": [
+        "cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* "
+      ]
+    }
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": null,
+        "Criterions": [
+          {
+            "Comment": "java-1.8.0-openjdk is earlier than 1:1.8.0-openjdk-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788001"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-accessibility is earlier than 1:1.8.0-openjdk-accessibility-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788002"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-accessibility-debug is earlier than 1:1.8.0-openjdk-accessibility-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788003"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-debug is earlier than 1:1.8.0-openjdk-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788004"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-demo is earlier than 1:1.8.0-openjdk-demo-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788005"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-demo-debug is earlier than 1:1.8.0-openjdk-demo-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788006"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-devel is earlier than 1:1.8.0-openjdk-devel-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788007"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-devel-debug is earlier than 1:1.8.0-openjdk-devel-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788008"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-headless is earlier than 1:1.8.0-openjdk-headless-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788009"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-headless-debug is earlier than 1:1.8.0-openjdk-headless-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788010"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-src is earlier than 1:1.8.0-openjdk-src-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788011"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-src-debug is earlier than 1:1.8.0-openjdk-src-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788012"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-javadoc is earlier than 1:1.8.0-openjdk-javadoc-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788013"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-javadoc-debug is earlier than 1:1.8.0-openjdk-javadoc-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788014"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-javadoc-zip is earlier than 1:1.8.0-openjdk-javadoc-zip-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788015"
+          },
+          {
+            "Comment": "java-1.8.0-openjdk-javadoc-zip-debug is earlier than 1:1.8.0-openjdk-javadoc-zip-debug-1.8.0.422.b05-1.an7",
+            "TestRef": "oval:cn.openanolis:tst:20240788016"
+          }
+        ]
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Anolis OS 7 is installed",
+        "TestRef": "oval:cn.openanolis:tst:1"
+      }
+    ]
+  }
+}

--- a/anolis/testdata/happy/anolis-7_els.oval.xml
+++ b/anolis/testdata/happy/anolis-7_els.oval.xml
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"?>
+<oval_definitions  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+  <generator>
+    <oval:product_name>Openanolis OVAL Generator</oval:product_name>
+    <oval:product_version>0.1</oval:product_version>
+    <oval:schema_version>5.11.2</oval:schema_version>
+    <oval:timestamp>2024-10-18T01:15:34</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition class="patch" id="oval:cn.openanolis:def:20240788" version="1">
+      <metadata>
+        <title>ANSA-2024:0788: java-1.8.0-openjdk security update (Important)</title>
+        <affected family="unix">
+          <platform>Anolis OS 7</platform>
+        </affected>
+        <reference ref_id="ANSA-2024:0788" ref_url="https://anas.openanolis.cn/errata/detail/ANSA-2024:0788" source="ANSA"/>
+        <description>Package updates are available for Anolis 7 that fix the following vulnerabilities:
+
+CVE-2024-21131:
+Vulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 3.7 (Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N).
+
+CVE-2024-21138:
+Vulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 3.7 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L).
+
+CVE-2024-21140:
+Vulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized read access to a subset of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 4.8 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N).
+
+CVE-2024-21144:
+Vulnerability in the Oracle Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Concurrency).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Oracle Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 3.7 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L).
+
+CVE-2024-21145:
+Vulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: 2D).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized read access to a subset of Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 4.8 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N).
+
+CVE-2024-21147:
+Vulnerability in the Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot).  Supported versions that are affected are Oracle Java SE: 8u411, 8u411-perf, 11.0.23, 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM for JDK: 17.0.11, 21.0.3, 22.0.1; Oracle GraalVM Enterprise Edition: 20.3.14 and  21.3.10. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition.  Successful attacks of this vulnerability can result in  unauthorized creation, deletion or modification access to critical data or all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data as well as  unauthorized access to critical data or complete access to all Oracle Java SE, Oracle GraalVM for JDK, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability can be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. This vulnerability also applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. CVSS 3.1 Base Score 7.4 (Confidentiality and Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N).</description>
+        <advisory from="anas.openanolis.cn">
+          <severity>Important</severity>
+          <rights>Copyright 2024 Openanolis</rights>
+          <issued date="2024-08-08"/>
+          <updated date="2024-08-13"/>
+          <cve cvss3="3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N" impact="Low" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21131" public="20240808">CVE-2024-21131</cve>
+          <cve cvss3="3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L" impact="Low" cwe="CWE-835" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21138" public="20240808">CVE-2024-21138</cve>
+          <cve cvss3="4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N" impact="Moderate" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21140" public="20240808">CVE-2024-21140</cve>
+          <cve cvss3="3.7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L" impact="Low" cwe="CWE-20-&gt;CWE-400" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21144" public="20240808">CVE-2024-21144</cve>
+          <cve cvss3="4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N" impact="Moderate" cwe="(CWE-125|CWE-787)" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21145" public="20240808">CVE-2024-21145</cve>
+          <cve cvss3="7.4/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N" impact="Important" href="https://anas.openanolis.cn/cves/detail/CVE-2024-21147" public="20240808">CVE-2024-21147</cve>
+          <affected_cpe_list>
+            <cpe>cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* </cpe>
+          </affected_cpe_list>
+        </advisory>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Anolis OS 7 is installed" test_ref="oval:cn.openanolis:tst:1"/>
+        <criteria operator="OR">
+          <criterion comment="java-1.8.0-openjdk is earlier than 1:1.8.0-openjdk-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788001"/>
+          <criterion comment="java-1.8.0-openjdk-accessibility is earlier than 1:1.8.0-openjdk-accessibility-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788002"/>
+          <criterion comment="java-1.8.0-openjdk-accessibility-debug is earlier than 1:1.8.0-openjdk-accessibility-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788003"/>
+          <criterion comment="java-1.8.0-openjdk-debug is earlier than 1:1.8.0-openjdk-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788004"/>
+          <criterion comment="java-1.8.0-openjdk-demo is earlier than 1:1.8.0-openjdk-demo-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788005"/>
+          <criterion comment="java-1.8.0-openjdk-demo-debug is earlier than 1:1.8.0-openjdk-demo-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788006"/>
+          <criterion comment="java-1.8.0-openjdk-devel is earlier than 1:1.8.0-openjdk-devel-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788007"/>
+          <criterion comment="java-1.8.0-openjdk-devel-debug is earlier than 1:1.8.0-openjdk-devel-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788008"/>
+          <criterion comment="java-1.8.0-openjdk-headless is earlier than 1:1.8.0-openjdk-headless-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788009"/>
+          <criterion comment="java-1.8.0-openjdk-headless-debug is earlier than 1:1.8.0-openjdk-headless-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788010"/>
+          <criterion comment="java-1.8.0-openjdk-src is earlier than 1:1.8.0-openjdk-src-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788011"/>
+          <criterion comment="java-1.8.0-openjdk-src-debug is earlier than 1:1.8.0-openjdk-src-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788012"/>
+          <criterion comment="java-1.8.0-openjdk-javadoc is earlier than 1:1.8.0-openjdk-javadoc-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788013"/>
+          <criterion comment="java-1.8.0-openjdk-javadoc-debug is earlier than 1:1.8.0-openjdk-javadoc-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788014"/>
+          <criterion comment="java-1.8.0-openjdk-javadoc-zip is earlier than 1:1.8.0-openjdk-javadoc-zip-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788015"/>
+          <criterion comment="java-1.8.0-openjdk-javadoc-zip-debug is earlier than 1:1.8.0-openjdk-javadoc-zip-debug-1.8.0.422.b05-1.an7" test_ref="oval:cn.openanolis:tst:20240788016"/>
+        </criteria>
+      </criteria>
+    </definition>
+    <definition class="patch" id="oval:cn.openanolis:def:20240787" version="1">
+      <metadata>
+        <title>ANSA-2024:0787: libndp security update (Important)</title>
+        <affected family="unix">
+          <platform>Anolis OS 7</platform>
+        </affected>
+        <reference ref_id="ANSA-2024:0787" ref_url="https://anas.openanolis.cn/errata/detail/ANSA-2024:0787" source="ANSA"/>
+        <description>Package updates are available for Anolis 7 that fix the following vulnerabilities:
+
+CVE-2024-5564:
+A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.</description>
+        <advisory from="anas.openanolis.cn">
+          <severity>Important</severity>
+          <rights>Copyright 2024 Openanolis</rights>
+          <issued date="2024-08-08"/>
+          <updated date="2024-08-13"/>
+          <cve cvss3="8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H" impact="Important" cwe="CWE-120" href="https://anas.openanolis.cn/cves/detail/CVE-2024-5564" public="20240729">CVE-2024-5564</cve>
+          <affected_cpe_list>
+            <cpe>cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* </cpe>
+          </affected_cpe_list>
+        </advisory>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Anolis OS 7 is installed" test_ref="oval:cn.openanolis:tst:1"/>
+        <criteria operator="OR">
+          <criterion comment="libndp is earlier than 0:1.2-10.an7" test_ref="oval:cn.openanolis:tst:20240787001"/>
+          <criterion comment="libndp-devel is earlier than 0:devel-1.2-10.an7" test_ref="oval:cn.openanolis:tst:20240787002"/>
+        </criteria>
+      </criteria>
+    </definition>
+    <definition class="patch" id="oval:cn.openanolis:def:20240786" version="1">
+      <metadata>
+        <title>ANSA-2024:0786: firefox security update (Important)</title>
+        <affected family="unix">
+          <platform>Anolis OS 7</platform>
+        </affected>
+        <reference ref_id="ANSA-2024:0786" ref_url="https://anas.openanolis.cn/errata/detail/ANSA-2024:0786" source="ANSA"/>
+        <description>Package updates are available for Anolis 7 that fix the following vulnerabilities:
+
+CVE-2024-6601:
+A race condition could lead to a cross-origin container obtaining permissions of the top-level origin. This vulnerability affects Firefox &lt; 128, Firefox ESR &lt; 115.13, Thunderbird &lt; 115.13, and Thunderbird &lt; 128.
+
+CVE-2024-6603:
+In an out-of-memory scenario an allocation could fail but free would have been called on the pointer afterwards leading to memory corruption. This vulnerability affects Firefox &lt; 128, Firefox ESR &lt; 115.13, Thunderbird &lt; 115.13, and Thunderbird &lt; 128.
+
+CVE-2024-6604:
+Memory safety bugs present in Firefox 127, Firefox ESR 115.12, and Thunderbird 115.12. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 128, Firefox ESR &lt; 115.13, Thunderbird &lt; 115.13, and Thunderbird &lt; 128.</description>
+        <advisory from="anas.openanolis.cn">
+          <severity>Important</severity>
+          <rights>Copyright 2024 Openanolis</rights>
+          <issued date="2024-08-08"/>
+          <updated date="2024-08-13"/>
+          <cve cvss3="6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N" impact="Moderate" cwe="CWE-281" href="https://anas.openanolis.cn/cves/detail/CVE-2024-6601" public="20240723">CVE-2024-6601</cve>
+          <cve cvss3="6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N" impact="Moderate" cwe="CWE-119" href="https://anas.openanolis.cn/cves/detail/CVE-2024-6603" public="20240723">CVE-2024-6603</cve>
+          <cve cvss3="7.5/CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H" impact="Important" cwe="CWE-120" href="https://anas.openanolis.cn/cves/detail/CVE-2024-6604" public="20240723">CVE-2024-6604</cve>
+          <affected_cpe_list>
+            <cpe>cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* </cpe>
+          </affected_cpe_list>
+        </advisory>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Anolis OS 7 is installed" test_ref="oval:cn.openanolis:tst:1"/>
+        <criteria operator="OR">
+          <criterion comment="firefox is earlier than 0:115.13.0-3.0.1.an7" test_ref="oval:cn.openanolis:tst:20240786001"/>
+        </criteria>
+      </criteria>
+    </definition>
+    <definition class="patch" id="oval:cn.openanolis:def:20240784" version="1">
+      <metadata>
+        <title>ANSA-2024:0784: pki-core security update (Important)</title>
+        <affected family="unix">
+          <platform>Anolis OS 7</platform>
+        </affected>
+        <reference ref_id="ANSA-2024:0784" ref_url="https://anas.openanolis.cn/errata/detail/ANSA-2024:0784" source="ANSA"/>
+        <description>Package updates are available for Anolis 7 that fix the following vulnerabilities:
+
+CVE-2023-4727:
+A flaw was found in dogtag-pki and pki-core. The token authentication scheme can be bypassed with a LDAP injection. By passing the query string parameter sessionID=*, an attacker can authenticate with an existing session saved in the LDAP directory server, which may lead to escalation of privilege.</description>
+        <advisory from="anas.openanolis.cn">
+          <severity>Important</severity>
+          <rights>Copyright 2024 Openanolis</rights>
+          <issued date="2024-08-08"/>
+          <updated date="2024-08-13"/>
+          <cve cvss3="7.5/CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H" impact="Important" cwe="CWE-305" href="https://anas.openanolis.cn/cves/detail/CVE-2023-4727" public="20240725">CVE-2023-4727</cve>
+          <affected_cpe_list>
+            <cpe>cpe:2.3:o:openanolis:anolis_os:7:*:*:*:*:*:*:* </cpe>
+          </affected_cpe_list>
+        </advisory>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Anolis OS 7 is installed" test_ref="oval:cn.openanolis:tst:1"/>
+        <criteria operator="OR">
+          <criterion comment="pki-symkey is earlier than 0:symkey-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784001"/>
+          <criterion comment="pki-tools is earlier than 0:tools-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784002"/>
+          <criterion comment="pki-core is earlier than 0:core-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784003"/>
+          <criterion comment="pki-base is earlier than 0:base-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784004"/>
+          <criterion comment="pki-base-java is earlier than 0:base-java-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784005"/>
+          <criterion comment="pki-ca is earlier than 0:ca-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784006"/>
+          <criterion comment="pki-javadoc is earlier than 0:javadoc-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784007"/>
+          <criterion comment="pki-kra is earlier than 0:kra-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784008"/>
+          <criterion comment="pki-server is earlier than 0:server-10.5.18-32.an7" test_ref="oval:cn.openanolis:tst:20240784009"/>
+        </criteria>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="at least one" version="1" comment="Anolis OS 7 is installed" id="oval:cn.openanolis:tst:1">
+      <object object_ref="oval:cn.openanolis:obj:1"/>
+      <state state_ref="oval:cn.openanolis:ste:1"/>
+    </textfilecontent54_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk is earlier than 1:1.8.0-openjdk-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788001">
+      <object object_ref="oval:cn.openanolis:obj:20240788001"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788001"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-accessibility is earlier than 1:1.8.0-openjdk-accessibility-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788002">
+      <object object_ref="oval:cn.openanolis:obj:20240788002"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788002"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-accessibility-debug is earlier than 1:1.8.0-openjdk-accessibility-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788003">
+      <object object_ref="oval:cn.openanolis:obj:20240788003"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788003"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-debug is earlier than 1:1.8.0-openjdk-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788004">
+      <object object_ref="oval:cn.openanolis:obj:20240788004"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788004"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-demo is earlier than 1:1.8.0-openjdk-demo-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788005">
+      <object object_ref="oval:cn.openanolis:obj:20240788005"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788005"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-demo-debug is earlier than 1:1.8.0-openjdk-demo-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788006">
+      <object object_ref="oval:cn.openanolis:obj:20240788006"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788006"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-devel is earlier than 1:1.8.0-openjdk-devel-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788007">
+      <object object_ref="oval:cn.openanolis:obj:20240788007"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788007"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-devel-debug is earlier than 1:1.8.0-openjdk-devel-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788008">
+      <object object_ref="oval:cn.openanolis:obj:20240788008"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788008"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-headless is earlier than 1:1.8.0-openjdk-headless-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788009">
+      <object object_ref="oval:cn.openanolis:obj:20240788009"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788009"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-headless-debug is earlier than 1:1.8.0-openjdk-headless-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788010">
+      <object object_ref="oval:cn.openanolis:obj:20240788010"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788010"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-src is earlier than 1:1.8.0-openjdk-src-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788011">
+      <object object_ref="oval:cn.openanolis:obj:20240788011"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788011"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-src-debug is earlier than 1:1.8.0-openjdk-src-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788012">
+      <object object_ref="oval:cn.openanolis:obj:20240788012"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788012"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-javadoc is earlier than 1:1.8.0-openjdk-javadoc-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788013">
+      <object object_ref="oval:cn.openanolis:obj:20240788013"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788013"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-javadoc-debug is earlier than 1:1.8.0-openjdk-javadoc-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788014">
+      <object object_ref="oval:cn.openanolis:obj:20240788014"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788014"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-javadoc-zip is earlier than 1:1.8.0-openjdk-javadoc-zip-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788015">
+      <object object_ref="oval:cn.openanolis:obj:20240788015"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788015"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="java-1.8.0-openjdk-javadoc-zip-debug is earlier than 1:1.8.0-openjdk-javadoc-zip-debug-1.8.0.422.b05-1.an7" version="1" id="oval:cn.openanolis:tst:20240788016">
+      <object object_ref="oval:cn.openanolis:obj:20240788016"/>
+      <state state_ref="oval:cn.openanolis:ste:20240788016"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="libndp is earlier than 0:1.2-10.an7" version="1" id="oval:cn.openanolis:tst:20240787001">
+      <object object_ref="oval:cn.openanolis:obj:20240787001"/>
+      <state state_ref="oval:cn.openanolis:ste:20240787001"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="libndp-devel is earlier than 0:devel-1.2-10.an7" version="1" id="oval:cn.openanolis:tst:20240787002">
+      <object object_ref="oval:cn.openanolis:obj:20240787002"/>
+      <state state_ref="oval:cn.openanolis:ste:20240787002"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="firefox is earlier than 0:115.13.0-3.0.1.an7" version="1" id="oval:cn.openanolis:tst:20240786001">
+      <object object_ref="oval:cn.openanolis:obj:20240786001"/>
+      <state state_ref="oval:cn.openanolis:ste:20240786001"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-symkey is earlier than 0:symkey-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784001">
+      <object object_ref="oval:cn.openanolis:obj:20240784001"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784001"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-tools is earlier than 0:tools-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784002">
+      <object object_ref="oval:cn.openanolis:obj:20240784002"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784002"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-core is earlier than 0:core-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784003">
+      <object object_ref="oval:cn.openanolis:obj:20240784003"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784003"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-base is earlier than 0:base-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784004">
+      <object object_ref="oval:cn.openanolis:obj:20240784004"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784004"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-base-java is earlier than 0:base-java-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784005">
+      <object object_ref="oval:cn.openanolis:obj:20240784005"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784005"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-ca is earlier than 0:ca-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784006">
+      <object object_ref="oval:cn.openanolis:obj:20240784006"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784006"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-javadoc is earlier than 0:javadoc-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784007">
+      <object object_ref="oval:cn.openanolis:obj:20240784007"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784007"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-kra is earlier than 0:kra-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784008">
+      <object object_ref="oval:cn.openanolis:obj:20240784008"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784008"/>
+    </rpminfo_test>
+    <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" comment="pki-server is earlier than 0:server-10.5.18-32.an7" version="1" id="oval:cn.openanolis:tst:20240784009">
+      <object object_ref="oval:cn.openanolis:obj:20240784009"/>
+      <state state_ref="oval:cn.openanolis:ste:20240784009"/>
+    </rpminfo_test>
+  </tests>
+  <objects>
+    <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:cn.openanolis:obj:1" version="1">
+      <path>/etc</path>
+      <filename>anolis-release</filename>
+      <pattern operation="pattern match">(Anolis OS release) \d.*</pattern>
+      <instance datatype="int">1</instance>
+    </textfilecontent54_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788001" version="1">
+      <name>java-1.8.0-openjdk</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788002" version="1">
+      <name>java-1.8.0-openjdk-accessibility</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788003" version="1">
+      <name>java-1.8.0-openjdk-accessibility-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788004" version="1">
+      <name>java-1.8.0-openjdk-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788005" version="1">
+      <name>java-1.8.0-openjdk-demo</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788006" version="1">
+      <name>java-1.8.0-openjdk-demo-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788007" version="1">
+      <name>java-1.8.0-openjdk-devel</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788008" version="1">
+      <name>java-1.8.0-openjdk-devel-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788009" version="1">
+      <name>java-1.8.0-openjdk-headless</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788010" version="1">
+      <name>java-1.8.0-openjdk-headless-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788011" version="1">
+      <name>java-1.8.0-openjdk-src</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788012" version="1">
+      <name>java-1.8.0-openjdk-src-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788013" version="1">
+      <name>java-1.8.0-openjdk-javadoc</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788014" version="1">
+      <name>java-1.8.0-openjdk-javadoc-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788015" version="1">
+      <name>java-1.8.0-openjdk-javadoc-zip</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240788016" version="1">
+      <name>java-1.8.0-openjdk-javadoc-zip-debug</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240787001" version="1">
+      <name>libndp</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240787002" version="1">
+      <name>libndp-devel</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240786001" version="1">
+      <name>firefox</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784001" version="1">
+      <name>pki-symkey</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784002" version="1">
+      <name>pki-tools</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784003" version="1">
+      <name>pki-core</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784004" version="1">
+      <name>pki-base</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784005" version="1">
+      <name>pki-base-java</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784006" version="1">
+      <name>pki-ca</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784007" version="1">
+      <name>pki-javadoc</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784008" version="1">
+      <name>pki-kra</name>
+    </rpminfo_object>
+    <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:obj:20240784009" version="1">
+      <name>pki-server</name>
+    </rpminfo_object>
+  </objects>
+  <states>
+    <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:cn.openanolis:ste:1" version="1">
+      <text operation="pattern match">7</text>
+    </textfilecontent54_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788001" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788002" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-accessibility-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788003" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-accessibility-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788004" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788005" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-demo-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788006" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-demo-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788007" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-devel-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788008" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-devel-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788009" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-headless-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788010" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-headless-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788011" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-src-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788012" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-src-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788013" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-javadoc-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788014" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-javadoc-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788015" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-javadoc-zip-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240788016" version="1">
+      <evr datatype="evr_string" operation="less than">1:1.8.0-openjdk-javadoc-zip-debug-1.8.0.422.b05-1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240787001" version="1">
+      <evr datatype="evr_string" operation="less than">0:1.2-10.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240787002" version="1">
+      <evr datatype="evr_string" operation="less than">0:devel-1.2-10.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240786001" version="1">
+      <evr datatype="evr_string" operation="less than">0:115.13.0-3.0.1.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784001" version="1">
+      <evr datatype="evr_string" operation="less than">0:symkey-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784002" version="1">
+      <evr datatype="evr_string" operation="less than">0:tools-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784003" version="1">
+      <evr datatype="evr_string" operation="less than">0:core-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784004" version="1">
+      <evr datatype="evr_string" operation="less than">0:base-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784005" version="1">
+      <evr datatype="evr_string" operation="less than">0:base-java-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784006" version="1">
+      <evr datatype="evr_string" operation="less than">0:ca-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784007" version="1">
+      <evr datatype="evr_string" operation="less than">0:javadoc-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784008" version="1">
+      <evr datatype="evr_string" operation="less than">0:kra-10.5.18-32.an7</evr>
+    </rpminfo_state>
+    <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:cn.openanolis:ste:20240784009" version="1">
+      <evr datatype="evr_string" operation="less than">0:server-10.5.18-32.an7</evr>
+    </rpminfo_state>
+  </states>
+</oval_definitions >

--- a/anolis/testdata/sad/anolis-7_els.oval.xml
+++ b/anolis/testdata/sad/anolis-7_els.oval.xml
@@ -1,0 +1,1 @@
+<oval_definitions xmlns

--- a/anolis/types.go
+++ b/anolis/types.go
@@ -1,0 +1,64 @@
+package anolis
+
+type Oval struct {
+	Definitions []Definition `xml:"definitions>definition"`
+}
+
+type Definition struct {
+	ID       string   `xml:"id,attr"`
+	Version  string   `xml:"version,attr"`
+	Class    string   `xml:"class,attr"`
+	Metadata Metadata `xml:"metadata"`
+	Criteria Criteria `xml:"criteria"`
+}
+
+type Metadata struct {
+	Title       string      `xml:"title"`
+	Affected    Affected    `xml:"affected"`
+	References  []Reference `xml:"reference"`
+	Description string      `xml:"description"`
+	Advisory    Advisory    `xml:"advisory"`
+}
+
+type Affected struct {
+	Family   string   `xml:"family,attr"`
+	Platform []string `xml:"platform"`
+}
+
+type Reference struct {
+	RefID  string `xml:"ref_id,attr"`
+	RefURL string `xml:"ref_url,attr"`
+	Source string `xml:"source,attr"`
+}
+
+type Advisory struct {
+	Severity        string   `xml:"severity"`
+	Issued          Issued   `xml:"issued"`
+	Updated         Issued   `xml:"updated"`
+	Cves            []Cve    `xml:"cve"`
+	AffectedCpeList []string `xml:"affected_cpe_list>cpe"`
+}
+
+type Cve struct {
+	ID     string `xml:",chardata"`
+	CVSS3  string `xml:"cvss3,attr"`
+	Impact string `xml:"impact,attr"`
+	Href   string `xml:"href,attr"`
+	CWE    string `xml:"cwe,attr"`
+	Public string `xml:"public,attr"`
+}
+
+type Issued struct {
+	Date string `xml:"date,attr"`
+}
+
+type Criteria struct {
+	Operator   string      `xml:"operator,attr"`
+	Criterias  []*Criteria `xml:"criteria"`
+	Criterions []Criterion `xml:"criterion"`
+}
+
+type Criterion struct {
+	Comment string `xml:"comment,attr"`
+	TestRef string `xml:"test_ref,attr"`
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/vuln-list-update/alpine"
 	alpineunfixed "github.com/aquasecurity/vuln-list-update/alpine-unfixed"
 	"github.com/aquasecurity/vuln-list-update/amazon"
+	"github.com/aquasecurity/vuln-list-update/anolis"
 	arch_linux "github.com/aquasecurity/vuln-list-update/arch"
 	"github.com/aquasecurity/vuln-list-update/chainguard"
 	"github.com/aquasecurity/vuln-list-update/cwe"
@@ -40,7 +41,7 @@ import (
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
 		"redhat-csaf-vex, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, "+
-		"chainguard, azure, openeuler)")
+		"chainguard, azure, openeuler,anolis)")
 	vulnListDir  = flag.String("vuln-list-dir", "", "vuln-list dir")
 	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
 	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
@@ -182,6 +183,11 @@ func run() error {
 		ec := openeuler.NewConfig()
 		if err := ec.Update(); err != nil {
 			return xerrors.Errorf("openEuler CVE update error: %w", err)
+		}
+	case "anolis":
+		ec := anolis.NewConfig()
+		if err := ec.Update(); err != nil {
+			return xerrors.Errorf("anolis update error: %w", err)
 		}
 	default:
 		return xerrors.New("unknown target")


### PR DESCRIPTION
This pull request adds support for Anolis OS in the vuln-list-update project.
The primary goal of this PR is to enable Trivy to support scanning for vulnerabilities in Anolis OS.
Please review the changes and provide feedback. Thanks!
![401729259678_ pic](https://github.com/user-attachments/assets/418776a0-8f72-45a5-8f56-ce6892e7d262)
