### PR TITLE
fix(azure): support of multiple `criterion`

### DIFF
--- a/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
+++ b/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
@@ -18,13 +18,17 @@
     "Severity": "Medium",
     "Description": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available."
   },
-  "Criteria": [
-    {
-      "Operator": "AND",
-      "Criterion": {
+  "Criteria": {
+    "Operator": "AND",
+    "Criterion": [
+      {
+        "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:52881000"
+      },
+      {
         "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
         "TestRef": "oval:com.microsoft.azurelinux:tst:52881003"
       }
-    }
-  ]
+    ]
+  }
 }

--- a/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
+++ b/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
@@ -1,0 +1,30 @@
+{
+  "Class": "vulnerability",
+  "ID": "oval:com.microsoft.azurelinux:def:52881",
+  "Version": "2",
+  "Metadata": {
+    "Title": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1",
+    "Affected": {
+      "Family": "unix",
+      "Platform": "Azure Linux"
+    },
+    "Reference": {
+      "RefID": "CVE-2023-29409",
+      "RefURL": "https://nvd.nist.gov/vuln/detail/CVE-2023-29409",
+      "Source": "CVE"
+    },
+    "Patchable": "true",
+    "AdvisoryID": "52881-2",
+    "Severity": "Medium",
+    "Description": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available."
+  },
+  "Criteria": [
+    {
+      "Operator": "AND",
+      "Criterion": {
+        "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:52881003"
+      }
+    }
+  ]
+}

--- a/mariner/testdata/golden/azure/3.0/definitions/2024/42064-1.json
+++ b/mariner/testdata/golden/azure/3.0/definitions/2024/42064-1.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176",
-      "TestRef": "oval:com.microsoft.azurelinux:tst:42064000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:42064000"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/azure/3.0/objects/objects.json
+++ b/mariner/testdata/golden/azure/3.0/objects/objects.json
@@ -4,6 +4,16 @@
       "ID": "oval:com.microsoft.azurelinux:obj:42064001",
       "Version": "1",
       "Name": "rubygem-rexml"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881004",
+      "Version": "1",
+      "Name": "golang"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881001",
+      "Version": "1",
+      "Name": "golang"
     }
   ]
 }

--- a/mariner/testdata/golden/azure/3.0/states/states.json
+++ b/mariner/testdata/golden/azure/3.0/states/states.json
@@ -8,6 +8,24 @@
         "Datatype": "evr_string",
         "Operation": "less than"
       }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881005",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:0.0.0.azl3",
+        "Datatype": "evr_string",
+        "Operation": "greater than"
+      }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881002",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:1.20.7-1.azl3",
+        "Datatype": "evr_string",
+        "Operation": "less than"
+      }
     }
   ]
 }

--- a/mariner/testdata/golden/azure/3.0/tests/tests.json
+++ b/mariner/testdata/golden/azure/3.0/tests/tests.json
@@ -11,6 +11,30 @@
       "State": {
         "StateRef": "oval:com.microsoft.azurelinux:ste:42064002"
       }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881003",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881004"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881005"
+      }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881000",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881001"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881002"
+      }
     }
   ]
 }

--- a/mariner/testdata/golden/mariner/1.0/definitions/2008/3173.json
+++ b/mariner/testdata/golden/mariner/1.0/definitions/2008/3173.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/1.0/definitions/2018/4209.json
+++ b/mariner/testdata/golden/mariner/1.0/definitions/2018/4209.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package libwebp is earlier than 1.0.3-1, affected by CVE-2018-25012",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000151"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package libwebp is earlier than 1.0.3-1, affected by CVE-2018-25012",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000151"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/1.0/definitions/2021/4820.json
+++ b/mariner/testdata/golden/mariner/1.0/definitions/2021/4820.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package glibc is earlier than 2.28-19, affected by CVE-2021-35942",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000145"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package glibc is earlier than 2.28-19, affected by CVE-2021-35942",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000145"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/2.0/definitions/2014/6933.json
+++ b/mariner/testdata/golden/mariner/2.0/definitions/2014/6933.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package unzip is installed with version 6.0 or earlier",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000269"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package unzip is installed with version 6.0 or earlier",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000269"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/2.0/definitions/2021/7412.json
+++ b/mariner/testdata/golden/mariner/2.0/definitions/2021/7412.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package wireshark is installed with version 3.4.4 or earlier",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000435"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package wireshark is installed with version 3.4.4 or earlier",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000435"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/2.0/definitions/2022/7700.json
+++ b/mariner/testdata/golden/mariner/2.0/definitions/2022/7700.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package mysql is installed with version 8.0.24 or earlier",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000854"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package mysql is installed with version 8.0.24 or earlier",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000854"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/2.0/definitions/2023/31872-1.json
+++ b/mariner/testdata/golden/mariner/2.0/definitions/2023/31872-1.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package edk2 is earlier than 20230301gitf80f052277c8-38, affected by CVE-2023-5678",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:31872000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package edk2 is earlier than 20230301gitf80f052277c8-38, affected by CVE-2023-5678",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:31872000"
+      }
+    ]
   }
 }

--- a/mariner/testdata/golden/mariner/2.0/definitions/2023/31880-1.json
+++ b/mariner/testdata/golden/mariner/2.0/definitions/2023/31880-1.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package openssl is earlier than 1.1.1k-28, affected by CVE-2023-5678",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:31880000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package openssl is earlier than 1.1.1k-28, affected by CVE-2023-5678",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:31880000"
+      }
+    ]
   }
 }

--- a/mariner/testdata/happy/azurelinux-3.0-oval.xml
+++ b/mariner/testdata/happy/azurelinux-3.0-oval.xml
@@ -24,21 +24,58 @@
         <criterion comment="Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176" test_ref="oval:com.microsoft.azurelinux:tst:42064000"/>
       </criteria>
     </definition>
+    <definition class="vulnerability" id="oval:com.microsoft.azurelinux:def:52881" version="2">
+      <metadata>
+        <title>CVE-2023-29409 affecting package golang for versions less than 1.20.7-1</title>
+        <affected family="unix">
+          <platform>Azure Linux</platform>
+        </affected>
+        <reference ref_id="CVE-2023-29409" ref_url="https://nvd.nist.gov/vuln/detail/CVE-2023-29409" source="CVE"/>
+        <patchable>true</patchable>
+        <advisory_id>52881-2</advisory_id>
+        <severity>Medium</severity>
+        <description>CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.</description>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881000"/>
+        <criterion comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881003"/>
+      </criteria>
+    </definition>
   </definitions>
   <tests>
     <linux-def:rpminfo_test check="at least one" comment="Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176" id="oval:com.microsoft.azurelinux:tst:42064000" version="1">
       <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:42064001"/>
       <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:42064002"/>
     </linux-def:rpminfo_test>
+    <linux-def:rpminfo_test check="at least one" comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" id="oval:com.microsoft.azurelinux:tst:52881003" version="1">
+      <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:52881004"/>
+      <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:52881005"/>
+    </linux-def:rpminfo_test>
+    <linux-def:rpminfo_test check="at least one" comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" id="oval:com.microsoft.azurelinux:tst:52881000" version="1">
+      <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:52881001"/>
+      <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:52881002"/>
+    </linux-def:rpminfo_test>
   </tests>
   <objects>
     <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:42064001" version="1">
       <linux-def:name>rubygem-rexml</linux-def:name>
     </linux-def:rpminfo_object>
+    <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:52881004" version="1">
+      <linux-def:name>golang</linux-def:name>
+    </linux-def:rpminfo_object>
+    <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:52881001" version="1">
+      <linux-def:name>golang</linux-def:name>
+    </linux-def:rpminfo_object>
   </objects>
   <states>
     <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:42064002" version="1">
       <linux-def:evr datatype="evr_string" operation="less than">0:3.2.8-1.azl3</linux-def:evr>
+    </linux-def:rpminfo_state>
+    <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:52881005" version="1">
+      <linux-def:evr datatype="evr_string" operation="greater than">0:0.0.0.azl3</linux-def:evr>
+    </linux-def:rpminfo_state>
+    <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:52881002" version="1">
+      <linux-def:evr datatype="evr_string" operation="less than">0:1.20.7-1.azl3</linux-def:evr>
     </linux-def:rpminfo_state>
   </states>
 </oval_definitions>

--- a/mariner/types.go
+++ b/mariner/types.go
@@ -54,8 +54,8 @@ type Definition struct {
 	Criteria Criteria `xml:"criteria" json:",omitempty"`
 }
 type Criteria struct {
-	Operator  string    `xml:"operator,attr" json:",omitempty"`
-	Criterion Criterion `xml:"criterion" json:",omitempty"`
+	Operator  string      `xml:"operator,attr" json:",omitempty"`
+	Criterion []Criterion `xml:"criterion" json:",omitempty"`
 }
 
 type Criterion struct {


### PR DESCRIPTION
## Description
We need to save all `criterion` for `definition`.
e.g. :
```xml
<criteria operator="AND">
  <criterion comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881000"/>
  <criterion comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881003"/>
</criteria>
```

Test GH actions run - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/11832818656/job/32970285972


## Changes

These changes affect only `definitions/<year>/*.json` files.

Before(https://github.com/aquasecurity/vuln-list/blob/b9a2b63e2a5e1c1db6dd31af38460eb2b666dcd2/azure/3.0/definitions/2023/52881-2.json#L23-L26):
```json
  "Criteria": {
    "Operator": "AND",
    "Criterion": {
      "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
      "TestRef": "oval:com.microsoft.azurelinux:tst:52881003"
    }
  }
```
After(https://github.com/DmitriyLewen/vuln-list/blob/96b886e4e225b3fe02d0bda1f0cebd72d68f4b9a/azure/3.0/definitions/2023/52881-2.json#L23-L31):
```json
  "Criteria": {
    "Operator": "AND",
    "Criterion": [
      {
        "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
        "TestRef": "oval:com.microsoft.azurelinux:tst:52881000"
      },
      {
        "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
        "TestRef": "oval:com.microsoft.azurelinux:tst:52881003"
      }
    ]
  }
```

## Related Issues:
- aquasecurity/trivy-db/issues/468