### PR TITLE
fix(azure): skip `grater then` criterions

### DIFF
--- a/mariner/mariner.go
+++ b/mariner/mariner.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb"
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/vuln-list-update/utils"
@@ -135,6 +136,10 @@ func (c Config) update(version, path string, isAzureLinux bool) error {
 	if !isAzureLinux {
 		dirPath = filepath.Join(c.dir, cblDir, version)
 	}
+
+	oval.Tests.RpminfoTests = lo.Filter(oval.Tests.RpminfoTests, func(test RpminfoTest, _ int) bool {
+		return !shouldSkipByComment(test.Comment)
+	})
 
 	// write tests/tests.json file
 	if err := utils.Write(filepath.Join(dirPath, testsDir, "tests.json"), oval.Tests); err != nil {

--- a/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
+++ b/mariner/testdata/golden/azure/3.0/definitions/2023/52881-2.json
@@ -1,0 +1,28 @@
+{
+  "Class": "vulnerability",
+  "ID": "oval:com.microsoft.azurelinux:def:52881",
+  "Version": "2",
+  "Metadata": {
+    "Title": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1",
+    "Affected": {
+      "Family": "unix",
+      "Platform": "Azure Linux"
+    },
+    "Reference": {
+      "RefID": "CVE-2023-29409",
+      "RefURL": "https://nvd.nist.gov/vuln/detail/CVE-2023-29409",
+      "Source": "CVE"
+    },
+    "Patchable": "true",
+    "AdvisoryID": "52881-2",
+    "Severity": "Medium",
+    "Description": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available."
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterion": {
+      "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+      "TestRef": "oval:com.microsoft.azurelinux:tst:52881000"
+    }
+  }
+}

--- a/mariner/testdata/golden/azure/3.0/objects/objects.json
+++ b/mariner/testdata/golden/azure/3.0/objects/objects.json
@@ -4,6 +4,16 @@
       "ID": "oval:com.microsoft.azurelinux:obj:42064001",
       "Version": "1",
       "Name": "rubygem-rexml"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881004",
+      "Version": "1",
+      "Name": "golang"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881001",
+      "Version": "1",
+      "Name": "golang"
     }
   ]
 }

--- a/mariner/testdata/golden/azure/3.0/states/states.json
+++ b/mariner/testdata/golden/azure/3.0/states/states.json
@@ -8,6 +8,24 @@
         "Datatype": "evr_string",
         "Operation": "less than"
       }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881005",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:0.0.0.azl3",
+        "Datatype": "evr_string",
+        "Operation": "greater than"
+      }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881002",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:1.20.7-1.azl3",
+        "Datatype": "evr_string",
+        "Operation": "less than"
+      }
     }
   ]
 }

--- a/mariner/testdata/golden/azure/3.0/tests/tests.json
+++ b/mariner/testdata/golden/azure/3.0/tests/tests.json
@@ -11,6 +11,30 @@
       "State": {
         "StateRef": "oval:com.microsoft.azurelinux:ste:42064002"
       }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881003",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881004"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881005"
+      }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881000",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881001"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881002"
+      }
     }
   ]
 }

--- a/mariner/testdata/golden/azure/3.0/tests/tests.json
+++ b/mariner/testdata/golden/azure/3.0/tests/tests.json
@@ -14,18 +14,6 @@
     },
     {
       "Check": "at least one",
-      "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
-      "ID": "oval:com.microsoft.azurelinux:tst:52881003",
-      "Version": "1",
-      "Object": {
-        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881004"
-      },
-      "State": {
-        "StateRef": "oval:com.microsoft.azurelinux:ste:52881005"
-      }
-    },
-    {
-      "Check": "at least one",
       "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
       "ID": "oval:com.microsoft.azurelinux:tst:52881000",
       "Version": "1",

--- a/mariner/testdata/happy/azurelinux-3.0-oval.xml
+++ b/mariner/testdata/happy/azurelinux-3.0-oval.xml
@@ -24,21 +24,58 @@
         <criterion comment="Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176" test_ref="oval:com.microsoft.azurelinux:tst:42064000"/>
       </criteria>
     </definition>
+    <definition class="vulnerability" id="oval:com.microsoft.azurelinux:def:52881" version="2">
+      <metadata>
+        <title>CVE-2023-29409 affecting package golang for versions less than 1.20.7-1</title>
+        <affected family="unix">
+          <platform>Azure Linux</platform>
+        </affected>
+        <reference ref_id="CVE-2023-29409" ref_url="https://nvd.nist.gov/vuln/detail/CVE-2023-29409" source="CVE"/>
+        <patchable>true</patchable>
+        <advisory_id>52881-2</advisory_id>
+        <severity>Medium</severity>
+        <description>CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.</description>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881000"/>
+        <criterion comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881003"/>
+      </criteria>
+    </definition>
   </definitions>
   <tests>
     <linux-def:rpminfo_test check="at least one" comment="Package rubygem-rexml is earlier than 3.2.8-1, affected by CVE-2024-35176" id="oval:com.microsoft.azurelinux:tst:42064000" version="1">
       <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:42064001"/>
       <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:42064002"/>
     </linux-def:rpminfo_test>
+    <linux-def:rpminfo_test check="at least one" comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" id="oval:com.microsoft.azurelinux:tst:52881003" version="1">
+      <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:52881004"/>
+      <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:52881005"/>
+    </linux-def:rpminfo_test>
+    <linux-def:rpminfo_test check="at least one" comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" id="oval:com.microsoft.azurelinux:tst:52881000" version="1">
+      <linux-def:object object_ref="oval:com.microsoft.azurelinux:obj:52881001"/>
+      <linux-def:state state_ref="oval:com.microsoft.azurelinux:ste:52881002"/>
+    </linux-def:rpminfo_test>
   </tests>
   <objects>
     <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:42064001" version="1">
       <linux-def:name>rubygem-rexml</linux-def:name>
     </linux-def:rpminfo_object>
+    <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:52881004" version="1">
+      <linux-def:name>golang</linux-def:name>
+    </linux-def:rpminfo_object>
+    <linux-def:rpminfo_object id="oval:com.microsoft.azurelinux:obj:52881001" version="1">
+      <linux-def:name>golang</linux-def:name>
+    </linux-def:rpminfo_object>
   </objects>
   <states>
     <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:42064002" version="1">
       <linux-def:evr datatype="evr_string" operation="less than">0:3.2.8-1.azl3</linux-def:evr>
+    </linux-def:rpminfo_state>
+    <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:52881005" version="1">
+      <linux-def:evr datatype="evr_string" operation="greater than">0:0.0.0.azl3</linux-def:evr>
+    </linux-def:rpminfo_state>
+    <linux-def:rpminfo_state id="oval:com.microsoft.azurelinux:ste:52881002" version="1">
+      <linux-def:evr datatype="evr_string" operation="less than">0:1.20.7-1.azl3</linux-def:evr>
     </linux-def:rpminfo_state>
   </states>
 </oval_definitions>

--- a/mariner/types.go
+++ b/mariner/types.go
@@ -121,7 +121,7 @@ type Evr struct {
 
 func (c Criteria) MarshalJSON() ([]byte, error) {
 	for _, criterion := range c.Criterion {
-		if strings.Contains(criterion.Comment, "earlier than") || strings.Contains(criterion.Comment, "or earlier") {
+		if !shouldSkipByComment(criterion.Comment) {
 			type Alias Criteria
 			return json.Marshal(&struct {
 				Criterion Criterion `json:",omitempty"`
@@ -133,4 +133,12 @@ func (c Criteria) MarshalJSON() ([]byte, error) {
 		}
 	}
 	return nil, xerrors.Errorf("supported cretirion operator not found")
+}
+
+// shouldSkipByComment tells when a test/criterion should be skipped based on a comment
+func shouldSkipByComment(comment string) bool {
+	if !strings.Contains(comment, "earlier than") && !strings.Contains(comment, "or earlier") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Description
Microsoft started using multiple `criterion` in `definition`:
```xml
<criteria operator="AND">
  <criterion comment="Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881000"/>
  <criterion comment="Package golang is greater than 0.0.0, affected by CVE-2023-29409" test_ref="oval:com.microsoft.azurelinux:tst:52881003"/>
</criteria>
```

Adding support for multiple `criteria` (#313) requires time to review and test.

So this PR adds a custom `MarshalJson` to store only one `earlier than` criterion to fix the problem with building `trivy-db` now.

test run - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/11854656796
trivy-db build test run - https://github.com/DmitriyLewen/trivy-db/actions/runs/11855682567/job/33040403541
```json
  "Criteria": {
    "Criterion": {
      "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
      "TestRef": "oval:com.microsoft.azurelinux:tst:52881000"
    },
    "Operator": "AND"
  }
```