### PR TITLE
chore(redhat): update url

### DIFF
--- a/redhat/csaf/vex.go
+++ b/redhat/csaf/vex.go
@@ -22,7 +22,7 @@ import (
 const (
 	vexDir  = "csaf-vex"
 	retry   = 5
-	baseURL = "https://access.redhat.com/security/data/csaf/v2/vex/"
+	baseURL = "https://security.access.redhat.com/data/csaf/v2/vex/"
 )
 
 type Option func(*Config)

--- a/redhat/oval/redhat.go
+++ b/redhat/oval/redhat.go
@@ -25,11 +25,11 @@ const (
 	ovalDir = "oval"
 	cpeDir  = "cpe"
 
-	urlFormat    = "https://www.redhat.com/security/data/oval/v2/%s"
+	urlFormat    = "https://security.access.redhat.com/data/oval/v2/%s"
 	retry        = 5
 	pulpManifest = "PULP_MANIFEST"
 
-	repoToCpeURL = "https://www.redhat.com/security/data/metrics/repository-to-cpe.json"
+	repoToCpeURL = "https://security.access.redhat.com/data/meta/v1/repository-to-cpe.json"
 
 	testsDir       = "tests"
 	objectsDir     = "objects"


### PR DESCRIPTION
> repository-to-cpe.json 	This file will be moved to the “/meta/v1” path. 	November 1, 2023* 
>
> * Important note: Since this file is intensively used, a copy of this file will remain in the "/data/metrics/" path until the end of 2024 to allow smooth migration.

https://www.redhat.com/en/blog/future-red-hat-security-data

> Note: Security data (CSAF, OVAL, SBOM, and other files) published by Red Hat Product Security was previously served from two locations:
>
>    https://access.redhat.com/security/data/*
>   https://www.redhat.com/security/data/*
>
> A new domain was recently created the scope of which (for the time being) is to serve this same data:
>
>    https://security.access.redhat.com/data/*

https://access.redhat.com/security/data