### PR TITLE
fix(nvd): don't update last_update if it returned no records

### DIFF
--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -105,11 +105,12 @@ func (u Updater) Update() error {
 
 	// If NVD didn't return records for all intervals
 	// we shouldn't update the last update as it might be a bug.
-	if totalEntries > 0 {
-		// Update last_updated.json at the end.
-		if err = utils.SetLastUpdatedDate(apiDir, u.lastModEndDate); err != nil {
-			return xerrors.Errorf("unable to update last_updated.json file: %w", err)
-		}
+	if totalEntries == 0 {
+		return nil
+	}
+	// Update last_updated.json at the end.
+	if err = utils.SetLastUpdatedDate(apiDir, u.lastModEndDate); err != nil {
+		return xerrors.Errorf("unable to update last_updated.json file: %w", err)
 	}
 
 	return nil

--- a/nvd/nvd_test.go
+++ b/nvd/nvd_test.go
@@ -85,6 +85,20 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
+			name:              "sad path 0 page",
+			maxResultsPerPage: 1,
+			wantApiKey:        "test_api_key",
+			lastUpdatedTime:   time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
+			fakeTimeNow:       time.Date(2023, 11, 30, 0, 0, 0, 0, time.UTC),
+			respFiles: map[string]string{
+				"resultsPerPage=1&startIndex=0": "testdata/fixtures/emptyResp.json",
+			},
+			respStatus: 200,
+			wantFiles: []string{
+				"last_updated.json",
+			},
+		},
+		{
 			name:              "503 response",
 			maxResultsPerPage: 10,
 			wantApiKey:        "test_api_key",

--- a/nvd/testdata/fixtures/emptyResp.json
+++ b/nvd/testdata/fixtures/emptyResp.json
@@ -1,0 +1,8 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 0,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2023-11-27T04:36:56.737"
+}


### PR DESCRIPTION
## Description
I found cases when `NVD` returns empty `vulnerabilities`:
- https://github.com/aquasecurity/vuln-list-update/actions/runs/11952931174/job/33319733712
- https://github.com/aquasecurity/vuln-list-update/actions/runs/11959096497/job/33340124175

For these runs we updated `last_update` time:
- https://github.com/aquasecurity/vuln-list-nvd/commit/30043e9c29cf127adf642f24d63d87b6791130e4
- https://github.com/aquasecurity/vuln-list-nvd/commit/f6c474ff1e0f0385d4e4fdeac15a2ccca6e98894

I think it was a bug in NVD because now I see vulnerabilities:
```bash
curl -s 'https://services.nvd.nist.gov/rest/json/cves/2.0/?lastModStartDate=2024-11-21T12:12:38&lastModEndDate=2024-11-21T18:09:55' | jq '.vulnerabilities | length'
208
```

But in any case, we lost changes in CVE from these intervals in`vuln-list-nvd` (see #327)

So we don't need to update `last_update` if NVD returns empty vulns.

## Related Issues
- Close #327