### PR TITLE
fix(redhat): change base URL for data API

### DIFF
--- a/redhat/securitydataapi/redhat.go
+++ b/redhat/securitydataapi/redhat.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	listURL = "https://access.redhat.com/labs/securitydataapi/cve.json?page=%d&after=%s&per_page=500"
-	cveURL  = "https://access.redhat.com/labs/securitydataapi/cve/%s.json"
+	listURL = "https://access.redhat.com/hydra/rest/securitydata/cve.json?page=%d&after=%s&per_page=500"
+	cveURL  = "https://access.redhat.com/hydra/rest/securitydata/cve/%s.json"
 	apiDir  = "api"
 
 	concurrency = 10


### PR DESCRIPTION
## Description
We got 403 error for RedHat advisories - https://github.com/aquasecurity/vuln-list-update/actions/runs/15430613251/job/43427586168

It looks like RedHat migrated to new base URL: `https://access.redhat.com/hydra/rest/securitydata`
See https://docs.redhat.com/en/documentation/red_hat_security_data_api/1.0/html/red_hat_security_data_api/overview

Test run with new BaseURL - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/15434557664/job/43438396158#step:8:10