### PR TITLE
fix(ubuntu): handle blank lines in ubuntu CVE parsing

### DIFF
--- a/ubuntu/testdata/blank_lines_in_description
+++ b/ubuntu/testdata/blank_lines_in_description
@@ -1,0 +1,25 @@
+Candidate: CVE-2017-5192
+PublicDate: 2017-09-26 14:29:00 UTC
+References:
+ https://docs.saltstack.com/en/2016.3/topics/releases/2015.8.13.html
+ https://www.cve.org/CVERecord?id=CVE-2017-5192
+Description:
+ When using the local_batch client from salt-api in SaltStack Salt before
+ 2015.8.13, 2016.3.x before 2016.3.5, and 2016.11.x before 2016.11.2,
+ external authentication is not respected, enabling all authentication to be
+ bypassed.
+
+ The LocalClient.cmd_batch() method client does not accept external_auth
+ credentials and so access to it from salt-api has been removed for
+ now. This vulnerability allows code execution for already-authenticated
+ users and is only in effect when running salt-api as the root user.
+Ubuntu-Description:
+Notes:
+Bugs:
+Priority: medium
+Discovered-by:
+Assigned-to:
+
+upstream_salt: released (2016.11.2+ds-1)
+precise_salt: DNE
+trusty_salt: ignored (end of standard support)

--- a/ubuntu/testdata/notes_with_continuation_lines
+++ b/ubuntu/testdata/notes_with_continuation_lines
@@ -1,15 +1,18 @@
-Candidate: CVE-2024-TEST
+Candidate: CVE-2017-0537
 PublicDate: 2024-01-01 00:00:00 UTC
 References:
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST
+ https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0537
 Description:
- Test vulnerability for notes with continuation lines.
+ Real example from ubuntu-cve-tracker for testing notes with continuation lines.
 Notes:
- jdstrand> this is a main note line that continues
-  on the next line with more details about the issue
- another> this is a second note that also continues
-  with additional information on this line
-  and even more info on this third continuation line
+ tyhicks> Patch submitter never verified that this was an issue on pure Linux
+  and upstream thinks that it could potentially be an issue in Android-specific
+  kernel changes
+ rodrigo-zaiden> ruby2.3 (xenial) was fixed back in release version
+  2.3.1-2~16.04.6. The patch that fixed this CVE came along
+  with other CVEs fixes (CVE-2017-0899, CVE-2017-0900,
+  CVE-2017-0901, CVE-2017-0902) and at that time this CVE
+  was not included in the changelog.
 Priority: medium
 Patches_test-package: needs-triage
 upstream_test-package: needs-triage

--- a/ubuntu/testdata/notes_with_continuation_lines
+++ b/ubuntu/testdata/notes_with_continuation_lines
@@ -1,18 +1,25 @@
 Candidate: CVE-2017-0537
-PublicDate: 2024-01-01 00:00:00 UTC
+PublicDate: 2017-03-08 01:59:00 UTC
 References:
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0537
+ https://source.android.com/security/bulletin/2017-01-01.html
+ https://android.googlesource.com/kernel/tegra.git/+/389b185cb2f17fff994dbdf8d4bac003d4b2b6b3%5E%21/#F0
+ https://lore.kernel.org/lkml/1484647168-30135-1-git-send-email-jilin@nvidia.com/#t
+ https://www.cve.org/CVERecord?id=CVE-2017-0537
 Description:
- Real example from ubuntu-cve-tracker for testing notes with continuation lines.
+ An information disclosure vulnerability in the kernel USB gadget driver
+ could enable a local malicious application to access data outside of its
+ permission levels. This issue is rated as Moderate because it first
+ requires compromising a privileged process. Product: Android. Versions:
+ Kernel-3.18. Android ID: A-31614969.
+Ubuntu-Description:
 Notes:
+ sbeattie> see android patch above
+ sbeattie> drivers/usb/gadget/configfs.c::usb_string_copy()
  tyhicks> Patch submitter never verified that this was an issue on pure Linux
   and upstream thinks that it could potentially be an issue in Android-specific
   kernel changes
- rodrigo-zaiden> ruby2.3 (xenial) was fixed back in release version
-  2.3.1-2~16.04.6. The patch that fixed this CVE came along
-  with other CVEs fixes (CVE-2017-0899, CVE-2017-0900,
-  CVE-2017-0901, CVE-2017-0902) and at that time this CVE
-  was not included in the changelog.
+ mdeslaur> The android package is in multiverse and not covered by ESM.
+ mdeslaur> Marking as ignored.
 Priority: medium
 Patches_test-package: needs-triage
 upstream_test-package: needs-triage

--- a/ubuntu/testdata/notes_with_continuation_lines
+++ b/ubuntu/testdata/notes_with_continuation_lines
@@ -1,0 +1,15 @@
+Candidate: CVE-2024-TEST
+PublicDate: 2024-01-01 00:00:00 UTC
+References:
+ https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST
+Description:
+ Test vulnerability for notes with continuation lines.
+Notes:
+ jdstrand> this is a main note line that continues
+  on the next line with more details about the issue
+ another> this is a second note that also continues
+  with additional information on this line
+  and even more info on this third continuation line
+Priority: medium
+Patches_test-package: needs-triage
+upstream_test-package: needs-triage

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -162,8 +162,25 @@ func parseNotesField(lines []string, currentIndex *int) []string {
 	i := *currentIndex
 	for i+1 < len(lines) && (strings.HasPrefix(lines[i+1], " ") || lines[i+1] == "") {
 		i++
-		if line := strings.TrimSpace(lines[i]); line != "" {
-			notes = append(notes, line)
+		if lines[i] == "" {
+			continue // Skip blank lines but don't stop parsing
+		}
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		
+		// If line starts with single space, it's a main note line
+		if strings.HasPrefix(lines[i], " ") && !strings.HasPrefix(lines[i], "  ") {
+			note := []string{line}
+			// Look for continuation lines that start with double space
+			for i+1 < len(lines) && strings.HasPrefix(lines[i+1], "  ") {
+				i++
+				if continuationLine := strings.TrimSpace(lines[i]); continuationLine != "" {
+					note = append(note, continuationLine)
+				}
+			}
+			notes = append(notes, strings.Join(note, " "))
 		}
 	}
 	*currentIndex = i

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -169,7 +169,7 @@ func parseNotesField(lines []string, currentIndex *int) []string {
 		if line == "" {
 			continue
 		}
-		
+
 		// If line starts with single space, it's a main note line
 		if strings.HasPrefix(lines[i], " ") && !strings.HasPrefix(lines[i], "  ") {
 			note := []string{line}

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -168,17 +168,15 @@ func parseNotesField(lines []string, currentIndex *int) []string {
 		}
 
 		// If line starts with single space, it's a main note line
-		if !strings.HasPrefix(lines[i], "  ") {
-			note := []string{line}
-			// Look for continuation lines that start with double space
-			for i+1 < len(lines) && strings.HasPrefix(lines[i+1], "  ") {
-				i++
-				if continuationLine := strings.TrimSpace(lines[i]); continuationLine != "" {
-					note = append(note, continuationLine)
-				}
+		note := []string{line}
+		// Look for continuation lines that start with double space
+		for i+1 < len(lines) && strings.HasPrefix(lines[i+1], "  ") {
+			i++
+			if continuationLine := strings.TrimSpace(lines[i]); continuationLine != "" {
+				note = append(note, continuationLine)
 			}
-			notes = append(notes, strings.Join(note, " "))
 		}
+		notes = append(notes, strings.Join(note, " "))
 	}
 	*currentIndex = i
 	return notes

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -144,78 +144,28 @@ func walkDir(root string) error {
 	return nil
 }
 
-// parseMultiLineField parses a multi-line field that can contain blank lines
 func parseMultiLineField(lines []string, currentIndex *int) []string {
 	var result []string
 	i := *currentIndex
-
-	for i+1 < len(lines) {
-		nextLine := lines[i+1]
-		// Continue if the line starts with space or is blank
-		if strings.HasPrefix(nextLine, " ") || nextLine == "" {
-			i++
-			line := strings.TrimSpace(lines[i])
-			// Only add non-empty lines to the result
-			if line != "" {
-				result = append(result, line)
-			}
-		} else {
-			// Stop when we encounter a line that doesn't start with space and isn't blank
-			break
+	for i+1 < len(lines) && (strings.HasPrefix(lines[i+1], " ") || lines[i+1] == "") {
+		i++
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			result = append(result, line)
 		}
 	}
-
 	*currentIndex = i
 	return result
 }
 
-// parseNotesField parses the Notes field which has nested structure and can contain blank lines
 func parseNotesField(lines []string, currentIndex *int) []string {
 	var notes []string
 	i := *currentIndex
-
-	for i+1 < len(lines) {
-		nextLine := lines[i+1]
-		// Stop if we encounter a line that doesn't start with space and isn't blank
-		if !strings.HasPrefix(nextLine, " ") && nextLine != "" {
-			break
-		}
-
-		// Skip blank lines
-		if nextLine == "" {
-			i++
-			continue
-		}
-
-		// If it starts with single space, it's a new note
-		if strings.HasPrefix(nextLine, " ") && !strings.HasPrefix(nextLine, "  ") {
-			i++
-			line := strings.TrimSpace(lines[i])
-			if line == "" {
-				continue
-			}
-
-			note := []string{line}
-			// Check for continuation lines (double space)
-			for i+1 < len(lines) {
-				continuationLine := lines[i+1]
-				if strings.HasPrefix(continuationLine, "  ") {
-					i++
-					l := strings.TrimSpace(lines[i])
-					if l != "" {
-						note = append(note, l)
-					}
-				} else {
-					break
-				}
-			}
-			notes = append(notes, strings.Join(note, " "))
-		} else {
-			// Skip other lines
-			i++
+	for i+1 < len(lines) && (strings.HasPrefix(lines[i+1], " ") || lines[i+1] == "") {
+		i++
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			notes = append(notes, line)
 		}
 	}
-
 	*currentIndex = i
 	return notes
 }

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -162,16 +162,13 @@ func parseNotesField(lines []string, currentIndex *int) []string {
 	i := *currentIndex
 	for i+1 < len(lines) && (strings.HasPrefix(lines[i+1], " ") || lines[i+1] == "") {
 		i++
-		if lines[i] == "" {
-			continue // Skip blank lines but don't stop parsing
-		}
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
 			continue
 		}
 
 		// If line starts with single space, it's a main note line
-		if strings.HasPrefix(lines[i], " ") && !strings.HasPrefix(lines[i], "  ") {
+		if !strings.HasPrefix(lines[i], "  ") {
 			note := []string{line}
 			// Look for continuation lines that start with double space
 			for i+1 < len(lines) && strings.HasPrefix(lines[i+1], "  ") {

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -465,14 +465,22 @@ func Test_parse(t *testing.T) {
 				filePath: "./testdata/notes_with_continuation_lines",
 			},
 			want: &Vulnerability{
-				Candidate:   "CVE-2017-0537",
-				References:  []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0537"},
-				Description: "Real example from ubuntu-cve-tracker for testing notes with continuation lines.",
+				Candidate: "CVE-2017-0537",
+				References: []string{
+					"https://source.android.com/security/bulletin/2017-01-01.html",
+					"https://android.googlesource.com/kernel/tegra.git/+/389b185cb2f17fff994dbdf8d4bac003d4b2b6b3%5E%21/#F0",
+					"https://lore.kernel.org/lkml/1484647168-30135-1-git-send-email-jilin@nvidia.com/#t",
+					"https://www.cve.org/CVERecord?id=CVE-2017-0537",
+				},
+				Description: "An information disclosure vulnerability in the kernel USB gadget driver could enable a local malicious application to access data outside of its permission levels. This issue is rated as Moderate because it first requires compromising a privileged process. Product: Android. Versions: Kernel-3.18. Android ID: A-31614969.",
 				Priority:    "medium",
-				PublicDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				PublicDate:  time.Date(2017, 3, 8, 1, 59, 0, 0, time.UTC),
 				Notes: []string{
+					"sbeattie> see android patch above",
+					"sbeattie> drivers/usb/gadget/configfs.c::usb_string_copy()",
 					"tyhicks> Patch submitter never verified that this was an issue on pure Linux and upstream thinks that it could potentially be an issue in Android-specific kernel changes",
-					"rodrigo-zaiden> ruby2.3 (xenial) was fixed back in release version 2.3.1-2~16.04.6. The patch that fixed this CVE came along with other CVEs fixes (CVE-2017-0899, CVE-2017-0900, CVE-2017-0901, CVE-2017-0902) and at that time this CVE was not included in the changelog.",
+					"mdeslaur> The android package is in multiverse and not covered by ESM.",
+					"mdeslaur> Marking as ignored.",
 				},
 				Patches: map[Package]Statuses{
 					Package("test-package"): {

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -465,11 +465,11 @@ func Test_parse(t *testing.T) {
 				filePath: "./testdata/notes_with_continuation_lines",
 			},
 			want: &Vulnerability{
-				Candidate:  "CVE-2024-TEST",
-				References: []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST"},
+				Candidate:   "CVE-2024-TEST",
+				References:  []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST"},
 				Description: "Test vulnerability for notes with continuation lines.",
-				Priority:   "medium",
-				PublicDate: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				Priority:    "medium",
+				PublicDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				Notes: []string{
 					"jdstrand> this is a main note line that continues on the next line with more details about the issue",
 					"another> this is a second note that also continues with additional information on this line and even more info on this third continuation line",

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -465,14 +465,14 @@ func Test_parse(t *testing.T) {
 				filePath: "./testdata/notes_with_continuation_lines",
 			},
 			want: &Vulnerability{
-				Candidate:   "CVE-2024-TEST",
-				References:  []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST"},
-				Description: "Test vulnerability for notes with continuation lines.",
+				Candidate:   "CVE-2017-0537",
+				References:  []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0537"},
+				Description: "Real example from ubuntu-cve-tracker for testing notes with continuation lines.",
 				Priority:    "medium",
 				PublicDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				Notes: []string{
-					"jdstrand> this is a main note line that continues on the next line with more details about the issue",
-					"another> this is a second note that also continues with additional information on this line and even more info on this third continuation line",
+					"tyhicks> Patch submitter never verified that this was an issue on pure Linux and upstream thinks that it could potentially be an issue in Android-specific kernel changes",
+					"rodrigo-zaiden> ruby2.3 (xenial) was fixed back in release version 2.3.1-2~16.04.6. The patch that fixed this CVE came along with other CVEs fixes (CVE-2017-0899, CVE-2017-0900, CVE-2017-0901, CVE-2017-0902) and at that time this CVE was not included in the changelog.",
 				},
 				Patches: map[Package]Statuses{
 					Package("test-package"): {

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -427,6 +427,38 @@ func Test_parse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "blank lines in description",
+			args: args{
+				filePath: "./testdata/blank_lines_in_description",
+			},
+			want: &Vulnerability{
+				Candidate: "CVE-2017-5192",
+				References: []string{
+					"https://docs.saltstack.com/en/2016.3/topics/releases/2015.8.13.html",
+					"https://www.cve.org/CVERecord?id=CVE-2017-5192",
+				},
+				Description: "When using the local_batch client from salt-api in SaltStack Salt before 2015.8.13, 2016.3.x before 2016.3.5, and 2016.11.x before 2016.11.2, external authentication is not respected, enabling all authentication to be bypassed. The LocalClient.cmd_batch() method client does not accept external_auth credentials and so access to it from salt-api has been removed for now. This vulnerability allows code execution for already-authenticated users and is only in effect when running salt-api as the root user.",
+				Priority:    "medium",
+				PublicDate:  time.Date(2017, 9, 26, 14, 29, 0, 0, time.UTC),
+				Patches: map[Package]Statuses{
+					Package("salt"): {
+						"upstream": Status{
+							Status: "released",
+							Note:   "2016.11.2+ds-1",
+						},
+						"precise": Status{
+							Status: "DNE",
+						},
+						"trusty": Status{
+							Status: "ignored",
+							Note:   "end of standard support",
+						},
+					},
+				},
+				UpstreamLinks: map[Package][]string{},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -459,6 +459,31 @@ func Test_parse(t *testing.T) {
 				UpstreamLinks: map[Package][]string{},
 			},
 		},
+		{
+			name: "notes with continuation lines",
+			args: args{
+				filePath: "./testdata/notes_with_continuation_lines",
+			},
+			want: &Vulnerability{
+				Candidate:  "CVE-2024-TEST",
+				References: []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-TEST"},
+				Description: "Test vulnerability for notes with continuation lines.",
+				Priority:   "medium",
+				PublicDate: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				Notes: []string{
+					"jdstrand> this is a main note line that continues on the next line with more details about the issue",
+					"another> this is a second note that also continues with additional information on this line and even more info on this third continuation line",
+				},
+				Patches: map[Package]Statuses{
+					Package("test-package"): {
+						"upstream": Status{
+							Status: "needs-triage",
+						},
+					},
+				},
+				UpstreamLinks: map[Package][]string{},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes parsing issues in ubuntu-cve-tracker where blank lines within multi-line fields caused data loss:

## Problem
The ubuntu.go parser stopped processing multi-line fields (Description, Notes, etc.) when encountering blank lines, causing:
- [CVE-2017-5192](https://git.launchpad.net/ubuntu-cve-tracker/tree/active/CVE-2017-5192#n11): Description truncated after blank line
- [CVE-2017-9779](https://git.launchpad.net/ubuntu-cve-tracker/tree/active/CVE-2017-9779#n13): Notes parsing incomplete
- Similar issues in other multi-line fields

## Test Results
- [CVE-2017-5192](https://git.launchpad.net/ubuntu-cve-tracker/tree/active/CVE-2017-5192#n11) now parses complete description (506 characters)
- All existing tests continue to pass
- New test cases cover blank line scenarios