### PR TITLE
fix(nvd): add `offset-from-UTC` suffix

### DIFF
--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -20,7 +20,6 @@ const (
 	retry             = 50
 	url20             = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
 	apiDir            = "api"
-	nvdTimeFormat     = "2006-01-02T15:04:05"
 	maxResultsPerPage = 2000
 	retryAfter        = 30 * time.Second
 	apiKeyEnvName     = "NVD_API_KEY"
@@ -201,27 +200,19 @@ func TimeIntervals(endTime time.Time) ([]TimeInterval, error) {
 	for endTime.Sub(lastUpdatedDate).Hours()/24 > 120 {
 		newLastUpdatedDate := lastUpdatedDate.Add(120 * 24 * time.Hour)
 		intervals = append(intervals, TimeInterval{
-			LastModStartDate: formatTime(lastUpdatedDate),
-			LastModEndDate:   formatTime(newLastUpdatedDate),
+			LastModStartDate: lastUpdatedDate.Format(time.RFC3339),
+			LastModEndDate:   newLastUpdatedDate.Format(time.RFC3339),
 		})
 		lastUpdatedDate = newLastUpdatedDate
 	}
 
 	// fill latest interval
 	intervals = append(intervals, TimeInterval{
-		LastModStartDate: formatTime(lastUpdatedDate),
-		LastModEndDate:   formatTime(endTime),
+		LastModStartDate: lastUpdatedDate.Format(time.RFC3339),
+		LastModEndDate:   endTime.Format(time.RFC3339),
 	})
 
 	return intervals, nil
-}
-
-// formatTime formats time in the format required by NVD API - `[YYYY][“-”][MM][“-”][DD][“T”][HH][“:”][MM][“:”][SS][Z]`.
-// e.g. `2021-10-22T13:36:00.000%2B01:00`
-func formatTime(t time.Time) string {
-	// NVD API requires offset-from-UTC suffix
-	// cf. https://github.com/aquasecurity/vuln-list-update/issues/361
-	return t.Format(nvdTimeFormat) + "%2B00:00"
 }
 
 func urlWithParams(baseUrl string, startIndex, resultsPerPage int, interval TimeInterval) (string, error) {

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -201,19 +201,27 @@ func TimeIntervals(endTime time.Time) ([]TimeInterval, error) {
 	for endTime.Sub(lastUpdatedDate).Hours()/24 > 120 {
 		newLastUpdatedDate := lastUpdatedDate.Add(120 * 24 * time.Hour)
 		intervals = append(intervals, TimeInterval{
-			LastModStartDate: lastUpdatedDate.Format(nvdTimeFormat),
-			LastModEndDate:   newLastUpdatedDate.Format(nvdTimeFormat),
+			LastModStartDate: formatTime(lastUpdatedDate),
+			LastModEndDate:   formatTime(newLastUpdatedDate),
 		})
 		lastUpdatedDate = newLastUpdatedDate
 	}
 
 	// fill latest interval
 	intervals = append(intervals, TimeInterval{
-		LastModStartDate: lastUpdatedDate.Format(nvdTimeFormat),
-		LastModEndDate:   endTime.Format(nvdTimeFormat),
+		LastModStartDate: formatTime(lastUpdatedDate),
+		LastModEndDate:   formatTime(endTime),
 	})
 
 	return intervals, nil
+}
+
+// formatTime formats time in the format required by NVD API - `[YYYY][“-”][MM][“-”][DD][“T”][HH][“:”][MM][“:”][SS][Z]`.
+// e.g. `2021-10-22T13:36:00.000%2B01:00`
+func formatTime(t time.Time) string {
+	// NVD API requires offset-from-UTC suffix
+	// cf. https://github.com/aquasecurity/vuln-list-update/issues/361
+	return t.Format(nvdTimeFormat) + "%2B00:00"
 }
 
 func urlWithParams(baseUrl string, startIndex, resultsPerPage int, interval TimeInterval) (string, error) {

--- a/nvd/nvd_test.go
+++ b/nvd/nvd_test.go
@@ -223,8 +223,8 @@ func TestTimeIntervals(t *testing.T) {
 			fakeTimeNow:     time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
 			wantIntervals: []nvd.TimeInterval{
 				{
-					LastModStartDate: "2023-11-26T00:00:00",
-					LastModEndDate:   "2023-11-28T00:00:00",
+					LastModStartDate: "2023-11-26T00:00:00Z",
+					LastModEndDate:   "2023-11-28T00:00:00Z",
 				},
 			},
 		},
@@ -234,12 +234,12 @@ func TestTimeIntervals(t *testing.T) {
 			fakeTimeNow:     time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
 			wantIntervals: []nvd.TimeInterval{
 				{
-					LastModStartDate: "2023-05-28T00:00:00",
-					LastModEndDate:   "2023-09-25T00:00:00",
+					LastModStartDate: "2023-05-28T00:00:00Z",
+					LastModEndDate:   "2023-09-25T00:00:00Z",
 				},
 				{
-					LastModStartDate: "2023-09-25T00:00:00",
-					LastModEndDate:   "2023-11-28T00:00:00",
+					LastModStartDate: "2023-09-25T00:00:00Z",
+					LastModEndDate:   "2023-11-28T00:00:00Z",
 				},
 			},
 		},
@@ -249,8 +249,8 @@ func TestTimeIntervals(t *testing.T) {
 			fakeTimeNow:     time.Date(1970, 03, 01, 0, 0, 0, 0, time.UTC),
 			wantIntervals: []nvd.TimeInterval{
 				{
-					LastModStartDate: "1970-01-01T00:00:00",
-					LastModEndDate:   "1970-03-01T00:00:00",
+					LastModStartDate: "1970-01-01T00:00:00Z",
+					LastModEndDate:   "1970-03-01T00:00:00Z",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
NVD requires `offset-from-UTC` for time parameters. 
Use `time.RFC3339` format.

More info in #361

test run - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/16514505804/job/46702716862

## Related Issues
- Close #361