### PR TITLE
feat: add Tags field support for ubuntu CVE parsing

### DIFF
--- a/ubuntu/testdata/tags_field_parsing
+++ b/ubuntu/testdata/tags_field_parsing
@@ -1,0 +1,23 @@
+PublicDateAtUSN: 2022-04-01 23:15:00 UTC
+Candidate: CVE-2022-22965
+PublicDate: 2022-04-01 23:15:00 UTC
+References:
+ https://example.com/reference1
+ https://example.com/reference2
+Description:
+ A Spring MVC or Spring WebFlux application running on JDK 9+ may be
+ vulnerable to remote code execution via data binding.
+Ubuntu-Description:
+Notes:
+Mitigation:
+Bugs:
+Priority: high
+Discovered-by:
+Assigned-to:
+Tags: cisa-kev epss-prioritized
+CVSS:
+
+Patches_libspring-java:
+upstream_libspring-java: released (5.3.18, 5.2.20)
+jammy_libspring-java: needed
+noble_libspring-java: needed

--- a/ubuntu/ubuntu.go
+++ b/ubuntu/ubuntu.go
@@ -54,6 +54,7 @@ type Vulnerability struct {
 	Priority          string
 	DiscoveredBy      string
 	AssignedTo        string
+	Tags              []string
 	Patches           map[Package]Statuses
 	UpstreamLinks     map[Package][]string
 }
@@ -269,6 +270,15 @@ func parse(r io.Reader) (vuln *Vulnerability, err error) {
 		if strings.HasPrefix(line, "Assigned-to:") {
 			line = strings.TrimPrefix(line, "Assigned-to:")
 			vuln.AssignedTo = strings.TrimSpace(line)
+			continue
+		}
+
+		// Parse Tags
+		if strings.HasPrefix(line, "Tags:") {
+			line = strings.TrimPrefix(line, "Tags:")
+			if tagsLine := strings.TrimSpace(line); tagsLine != "" {
+				vuln.Tags = strings.Fields(tagsLine)
+			}
 			continue
 		}
 

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -426,6 +426,39 @@ func Test_parse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tags field parsing",
+			args: args{
+				filePath: "./testdata/tags_field_parsing",
+			},
+			want: &Vulnerability{
+				Candidate: "CVE-2022-22965",
+				References: []string{
+					"https://example.com/reference1",
+					"https://example.com/reference2",
+				},
+				Description: "A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution via data binding.",
+				Priority:    "high",
+				Tags:        []string{"cisa-kev", "epss-prioritized"},
+				PublicDateAtUSN: time.Date(2022, 4, 1, 23, 15, 0, 0, time.UTC),
+				PublicDate:      time.Date(2022, 4, 1, 23, 15, 0, 0, time.UTC),
+				Patches: map[Package]Statuses{
+					Package("libspring-java"): {
+						"upstream": Status{
+							Status: "released",
+							Note:   "5.3.18, 5.2.20",
+						},
+						"jammy": Status{
+							Status: "needed",
+						},
+						"noble": Status{
+							Status: "needed",
+						},
+					},
+				},
+				UpstreamLinks: map[Package][]string{},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ubuntu/ubuntu_test.go
+++ b/ubuntu/ubuntu_test.go
@@ -437,9 +437,9 @@ func Test_parse(t *testing.T) {
 					"https://example.com/reference1",
 					"https://example.com/reference2",
 				},
-				Description: "A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution via data binding.",
-				Priority:    "high",
-				Tags:        []string{"cisa-kev", "epss-prioritized"},
+				Description:     "A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution via data binding.",
+				Priority:        "high",
+				Tags:            []string{"cisa-kev", "epss-prioritized"},
 				PublicDateAtUSN: time.Date(2022, 4, 1, 23, 15, 0, 0, time.UTC),
 				PublicDate:      time.Date(2022, 4, 1, 23, 15, 0, 0, time.UTC),
 				Patches: map[Package]Statuses{


### PR DESCRIPTION
This PR adds support for parsing the Tags field in ubuntu-cve-tracker data with proper space separation:

## Changes
- Add `Tags []string` field to Vulnerability struct
- Implement Tags parsing logic using `strings.Fields()` for space separation
- Add comprehensive test case using [CVE-2022-22965](https://git.launchpad.net/ubuntu-cve-tracker/tree/active/CVE-2022-22965) data
- Support both single and multiple space-separated tags

## Example
Before: Tags field not supported, CISA KEV information lost

After: Tags field properly captured in generated JSON

### Actual generated output:
```bash
$ jq '.Tags' vuln-list/ubuntu/2022/CVE-2022-22965.json
[
  "cisa-kev",
  "epss-prioritized"
]
```

The Tags field is now successfully parsed and included in the generated JSON output.