### PR TITLE
fix(debian): use correct security sources URL

### DIFF
--- a/debian/tracker/debian.go
+++ b/debian/tracker/debian.go
@@ -23,7 +23,7 @@ const (
 	trackerDir         = "tracker"
 	securityTrackerURL = "https://salsa.debian.org/security-tracker-team/security-tracker/-/archive/master/security-tracker-master.tar.gz//security-tracker-master"
 	sourcesURL         = "https://ftp.debian.org/debian/dists/%s/%s/source/Sources.gz"
-	securitySourcesURL = "https://security.debian.org/debian-security/dists/%s/updates/%s/source/Sources.gz"
+	securitySourcesURL = "https://security.debian.org/debian-security/dists/%s-security/updates/%s/source/Sources.xz"
 )
 
 var (


### PR DESCRIPTION
## Description
Use correct security sources URL

Test run - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/17542868478
Updated data - https://github.com/DmitriyLewen/vuln-list-debian/tree/c8e39ec6cc451ae8be00d933abeef47446900777/tracker/updates-source

## Related Issues
- Close #371
