### PR TITLE
ci(redhat): add `remove-unwanted-software`

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -12,6 +12,17 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
       VULN_LIST_DIR: "vuln-list-redhat"
     steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+      with:
+        remove-android: 'true'
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+        remove-large-packages: 'true'
+        remove-cached-tools: 'true'
+        remove-swapfile: 'true'
     - name: Check out code
       uses: actions/checkout@v5
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -12,6 +12,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
       VULN_LIST_DIR: "vuln-list-redhat"
     steps:
+    # vuln-list-redhat dir uses more than 20GB of storage
     - name: Maximize build space
       uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
       with:
@@ -23,6 +24,7 @@ jobs:
         remove-large-packages: 'true'
         remove-cached-tools: 'true'
         remove-swapfile: 'true'
+
     - name: Check out code
       uses: actions/checkout@v5
 


### PR DESCRIPTION
## Description
The size of vuln-list-redhat is more than 20 GB:
```
➜ du -sh ./vuln-list-redhat        
 20G	./vuln-list-redhat
```

And we can’t clone this repo — see [GitHub Actions log](https://github.com/aquasecurity/vuln-list-update/actions/runs/18271712405/job/52015219867).

We need to use `remove-unwanted-software` to free up more disk space.

Test run - https://github.com/DmitriyLewen/vuln-list-update/actions/runs/18272869389/job/52018453626