### PR TITLE
feat(suse): add cvrf CVE feed

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -72,6 +72,10 @@ jobs:
         run: ./scripts/update.sh suse-cvrf "SUSE CVRF"
 
       - if: always()
+        name: SUSE CVE CVRF
+        run: ./scripts/update.sh suse-cvrf-cve "SUSE CVE CVRF"
+
+      - if: always()
         name: GitLab Advisory Database
         run: ./scripts/update.sh glad "GitLab Advisory Database"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/aquasecurity/vuln-list/
 $ vuln-list-update -h
 Usage of vuln-list-update:
   -target string
-        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler, echo, minimos, rootio, seal)
+        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, suse-cvrf-cve, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler, echo, minimos, rootio, seal)
   -target-branch string
     	alternative repository branch (only glad)
   -target-uri string

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aquasecurity/vuln-list-update/rootio"
 	"github.com/aquasecurity/vuln-list-update/seal"
 	susecvrf "github.com/aquasecurity/vuln-list-update/suse/cvrf"
+	susecvrfcve "github.com/aquasecurity/vuln-list-update/suse/cvrfcve"
 	"github.com/aquasecurity/vuln-list-update/ubuntu"
 	"github.com/aquasecurity/vuln-list-update/utils"
 	"github.com/aquasecurity/vuln-list-update/wolfi"
@@ -39,7 +40,7 @@ import (
 
 var (
 	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
-		"redhat-csaf-vex, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, glad, cwe, osvdev, mariner, kevc, wolfi, "+
+		"redhat-csaf-vex, debian, ubuntu, amazon, oracle-oval, suse-cvrf, suse-cvrf-cve, photon, arch-linux, glad, cwe, osvdev, mariner, kevc, wolfi, "+
 		"chainguard, azure, openeuler, echo, minimos, eoldates, rootio)")
 	vulnListDir  = flag.String("vuln-list-dir", "", "vuln-list dir")
 	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
@@ -112,6 +113,11 @@ func run() error {
 		sc := susecvrf.NewConfig()
 		if err := sc.Update(); err != nil {
 			return xerrors.Errorf("SUSE CVRF update error: %w", err)
+		}
+	case "suse-cvrf-cve":
+		sc := susecvrfcve.NewConfig()
+		if err := sc.Update(); err != nil {
+			return xerrors.Errorf("SUSE CVE CVRF update error: %w", err)
 		}
 	case "photon":
 		pc := photon.NewConfig()

--- a/suse/cvrf/cvrf.go
+++ b/suse/cvrf/cvrf.go
@@ -1,23 +1,17 @@
 package cvrf
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/bzip2"
-	"compress/gzip"
 	"encoding/xml"
-	"errors"
 	"fmt"
-	"io"
 	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/vuln-list-update/suse/cvrfarchive"
 	"github.com/aquasecurity/vuln-list-update/utils"
 )
 
@@ -47,81 +41,21 @@ func NewConfig() Config {
 func (c Config) Update() error {
 	log.Print("Fetching SUSE CVRF archive...")
 
-	// The SUSE server is sometimes unstable, so download the whole archive into
-	// memory before processing. Streaming directly from the HTTP response would
-	// make it hard to distinguish a mid-transfer disconnection (which surfaces
-	// as a truncated tar) from a legitimate parse error. The archive is only a
-	// few hundred MB, which fits comfortably in memory on CI runners.
-	body, err := utils.FetchURL(c.URL, "", retries)
-	if err != nil {
-		return xerrors.Errorf("failed to download CVRF archive: %w", err)
-	}
-
-	var decompressed io.Reader
-	switch {
-	case strings.HasSuffix(c.URL, ".tar.bz2"):
-		// The upstream archive is .tar.bz2, which is the only format used in production.
-		decompressed = bzip2.NewReader(bytes.NewReader(body))
-	case strings.HasSuffix(c.URL, ".tar.gz"):
-		// Go's compress/bzip2 lacks a Writer, so tests use .tar.gz instead.
-		gr, err := gzip.NewReader(bytes.NewReader(body))
-		if err != nil {
-			return xerrors.Errorf("failed to decompress gzip: %w", err)
-		}
-		defer gr.Close()
-		decompressed = gr
-	default:
-		return xerrors.Errorf("unsupported archive format: %s", c.URL)
-	}
-	tr := tar.NewReader(decompressed)
-
-	for {
-		hdr, err := tr.Next()
-		switch {
-		case errors.Is(err, io.EOF):
-			return nil
-		case err != nil:
-			return xerrors.Errorf("failed to read tar entry: %w", err)
-		case hdr.Typeflag != tar.TypeReg:
-			continue
-		}
-
-		filename := filepath.Base(hdr.Name)
-		// archive contains non-XML files (e.g. LICENSE), so skip them
-		if !strings.HasSuffix(filename, ".xml") {
-			continue
-		}
-		match := fileRegexp.FindStringSubmatch(filename)
-		if match == nil {
-			continue
-		}
+	return cvrfarchive.Walk(c.URL, retries, fileRegexp, func(e cvrfarchive.Entry) error {
+		match := fileRegexp.FindStringSubmatch(e.Filename)
 		osName := match[1]
 
-		data, err := io.ReadAll(tr)
-		if err != nil {
-			return xerrors.Errorf("failed to read tar entry data: %w", err)
-		}
-
-		if len(data) == 0 {
-			log.Printf("empty CVRF xml: %s", filename)
-			continue
-		}
-
-		if !utf8.Valid(data) {
-			log.Printf("invalid UTF-8: %s", filename)
-			data = []byte(strings.ToValidUTF8(string(data), ""))
-		}
-
 		var cv Cvrf
-		if err = xml.Unmarshal(data, &cv); err != nil {
-			return xerrors.Errorf("failed to decode SUSE XML (%s): %w", filename, err)
+		if err := xml.Unmarshal(e.Data, &cv); err != nil {
+			return xerrors.Errorf("failed to decode SUSE XML (%s): %w", e.Filename, err)
 		}
 
 		dir := filepath.Join(cvrfDir, suseDir, osName)
-		if err = c.saveCvrfPerYear(dir, cv.Tracking.ID, cv); err != nil {
+		if err := c.saveCvrfPerYear(dir, cv.Tracking.ID, cv); err != nil {
 			return xerrors.Errorf("failed to save CVRF: %w", err)
 		}
-	}
+		return nil
+	})
 }
 
 func (c Config) saveCvrfPerYear(dirName string, cvrfID string, data Cvrf) error {

--- a/suse/cvrfarchive/archive.go
+++ b/suse/cvrfarchive/archive.go
@@ -1,0 +1,103 @@
+// Package cvrfarchive walks SUSE CVRF tar archives published at
+// http://ftp.suse.com/pub/projects/security/. It hides the
+// download/decompress/tar plumbing so feed-specific code only needs
+// to handle XML decoding and persistence.
+package cvrfarchive
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"errors"
+	"io"
+	"log"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+// Entry is a single XML document extracted from a SUSE CVRF archive.
+// Data is guaranteed to be valid UTF-8 (invalid bytes are stripped).
+type Entry struct {
+	Filename string
+	Data     []byte
+}
+
+// Walk downloads a SUSE CVRF archive from url, decompresses it
+// (bzip2 or gzip, detected by the URL suffix) and invokes handler
+// for every .xml entry whose base name matches nameRegexp.
+// Non-regular tar entries, empty files and non-XML files are skipped;
+// invalid UTF-8 byte sequences are stripped from the data.
+func Walk(url string, retries int, nameRegexp *regexp.Regexp, handler func(Entry) error) error {
+	// The SUSE server is sometimes unstable, so download the whole archive into
+	// memory before processing. Streaming directly from the HTTP response would
+	// make it hard to distinguish a mid-transfer disconnection (which surfaces
+	// as a truncated tar) from a legitimate parse error. The archive is only a
+	// few hundred MB, which fits comfortably in memory on CI runners.
+	body, err := utils.FetchURL(url, "", retries)
+	if err != nil {
+		return xerrors.Errorf("failed to download archive: %w", err)
+	}
+
+	decompressed, err := decompress(url, body)
+	if err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(decompressed)
+	for {
+		hdr, err := tr.Next()
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil
+		case err != nil:
+			return xerrors.Errorf("failed to read tar entry: %w", err)
+		case hdr.Typeflag != tar.TypeReg:
+			continue
+		}
+
+		filename := filepath.Base(hdr.Name)
+		if !strings.HasSuffix(filename, ".xml") {
+			continue
+		}
+		if nameRegexp != nil && !nameRegexp.MatchString(filename) {
+			continue
+		}
+
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return xerrors.Errorf("failed to read tar entry data: %w", err)
+		}
+		if len(data) == 0 {
+			log.Printf("empty xml: %s", filename)
+			continue
+		}
+		if !utf8.Valid(data) {
+			log.Printf("invalid UTF-8: %s", filename)
+			data = []byte(strings.ToValidUTF8(string(data), ""))
+		}
+
+		if err := handler(Entry{Filename: filename, Data: data}); err != nil {
+			return err
+		}
+	}
+}
+
+func decompress(url string, body []byte) (io.Reader, error) {
+	switch {
+	case strings.HasSuffix(url, ".tar.bz2"):
+		// The upstream archive is .tar.bz2, which is the only format used in production.
+		return bzip2.NewReader(bytes.NewReader(body)), nil
+	case strings.HasSuffix(url, ".tar.gz"):
+		// Go's compress/bzip2 lacks a Writer, so tests use .tar.gz instead.
+		return gzip.NewReader(bytes.NewReader(body))
+	default:
+		return nil, xerrors.Errorf("unsupported archive format: %s", url)
+	}
+}

--- a/suse/cvrfcve/cvrfcve.go
+++ b/suse/cvrfcve/cvrfcve.go
@@ -1,0 +1,65 @@
+package cvrfcve
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/vuln-list-update/suse/cvrfarchive"
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+const (
+	cvrfCVEArchiveURL = "http://ftp.suse.com/pub/projects/security/cvrf-cve.tar.bz2"
+	cvrfDir           = "cvrf"
+	suseCVEDir        = "suse-cves"
+	retries           = 5
+)
+
+var fileRegexp = regexp.MustCompile(`^cvrf-(CVE-\d{4}-\d+)\.xml$`)
+
+type Config struct {
+	VulnListDir string
+	URL         string
+	AppFs       afero.Fs
+}
+
+func NewConfig() Config {
+	return Config{
+		VulnListDir: utils.VulnListDir(),
+		URL:         cvrfCVEArchiveURL,
+		AppFs:       afero.NewOsFs(),
+	}
+}
+
+func (c Config) Update() error {
+	log.Print("Fetching SUSE CVE CVRF archive...")
+
+	return cvrfarchive.Walk(c.URL, retries, fileRegexp, func(e cvrfarchive.Entry) error {
+		// CVE ID is taken from the file name, already validated by fileRegexp.
+		cveID := fileRegexp.FindStringSubmatch(e.Filename)[1]
+
+		var cv Cvrf
+		if err := xml.Unmarshal(e.Data, &cv); err != nil {
+			return xerrors.Errorf("failed to decode SUSE CVE CVRF XML (%s): %w", e.Filename, err)
+		}
+
+		return c.saveCVEPerYear(cveID, cv)
+	})
+}
+
+func (c Config) saveCVEPerYear(cveID string, data Cvrf) error {
+	year := strings.Split(cveID, "-")[1]
+	yearDir := filepath.Join(c.VulnListDir, cvrfDir, suseCVEDir, year)
+	fileName := fmt.Sprintf("%s.json", cveID)
+	if err := utils.WriteJSON(c.AppFs, yearDir, fileName, data); err != nil {
+		return xerrors.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}

--- a/suse/cvrfcve/cvrfcve_test.go
+++ b/suse/cvrfcve/cvrfcve_test.go
@@ -1,0 +1,126 @@
+package cvrfcve_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/vuln-list-update/suse/cvrfcve"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+const goldenDir = "testdata/golden"
+
+// createArchive creates a tar.gz archive from the given directory.
+// gzip is used instead of bzip2 because Go's compress/bzip2 package
+// only provides a Reader. The production code detects the format by
+// URL suffix and handles both .tar.bz2 and .tar.gz.
+func createArchive(t *testing.T, dir string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.AddFS(os.DirFS(dir)))
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func TestConfig_Update(t *testing.T) {
+	testCases := []struct {
+		name       string
+		appFs      afero.Fs
+		archiveDir string
+		// wantGolden lists the golden file basenames expected to be produced
+		// for this case (empty when wantErr is set). Each name is resolved
+		// against testdata/golden/ and matched to a produced file by basename.
+		wantGolden []string
+		wantErr    string
+	}{
+		{
+			name:       "positive test",
+			appFs:      afero.NewMemMapFs(),
+			archiveDir: "testdata/cvrfcve",
+			wantGolden: []string{
+				"CVE-1234-12345.json",
+				"CVE-2014-6271.json",
+			},
+		},
+		{
+			name:       "broken XML",
+			appFs:      afero.NewMemMapFs(),
+			archiveDir: "testdata/broken-cvrfcve",
+			wantErr:    "failed to decode SUSE CVE CVRF XML",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			archiveData := createArchive(t, tc.archiveDir)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write(archiveData)
+				assert.NoError(t, err, tc.name)
+			}))
+			defer ts.Close()
+
+			c := cvrfcve.Config{
+				VulnListDir: t.TempDir(),
+				URL:         ts.URL + "/cvrf-cve.tar.gz",
+				AppFs:       tc.appFs,
+			}
+			err := c.Update()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr, tc.name)
+				return
+			}
+			require.NoError(t, err, tc.name)
+
+			// Collect everything the updater wrote, keyed by basename. Basenames
+			// are unique because CVE IDs are unique across years.
+			produced := map[string][]byte{}
+			err = afero.Walk(c.AppFs, c.VulnListDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				data, err := afero.ReadFile(c.AppFs, path)
+				if err != nil {
+					return err
+				}
+				produced[filepath.Base(path)] = data
+				return nil
+			})
+			require.NoError(t, err, tc.name)
+
+			assert.Len(t, produced, len(tc.wantGolden), tc.name)
+			for _, name := range tc.wantGolden {
+				actual, ok := produced[name]
+				require.True(t, ok, "%s: %s was not produced", tc.name, name)
+
+				goldenPath := filepath.Join(goldenDir, name)
+				if *update {
+					require.NoError(t, os.WriteFile(goldenPath, actual, 0o644), tc.name)
+				}
+				expected, err := os.ReadFile(goldenPath)
+				require.NoError(t, err, tc.name)
+
+				assert.Equal(t, string(expected), string(actual), tc.name)
+			}
+		})
+	}
+}

--- a/suse/cvrfcve/testdata/broken-cvrfcve/cvrf-CVE-2014-6271.xml
+++ b/suse/cvrfcve/testdata/broken-cvrfcve/cvrf-CVE-2014-6271.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/cvrf">
+  <DocumentTitle xml:lang="en">CVE-2014-6271</DocumentTitle>
+  <Vulnerability xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln" Ordinal="1">
+    <CVE>CVE-2014-6271</CVE>

--- a/suse/cvrfcve/testdata/cvrfcve/cvrf-CVE-1234-12345.xml
+++ b/suse/cvrfcve/testdata/cvrfcve/cvrf-CVE-1234-12345.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/cvrf">
+  <DocumentTitle xml:lang="en">CVE-1234-12345</DocumentTitle>
+  <DocumentTracking>
+    <Identification>
+      <ID>SUSE CVE-1234-12345</ID>
+    </Identification>
+  </DocumentTracking>
+  <Vulnerability xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln" Ordinal="1">
+    <CVE>CVE-1234-12345</CVE>
+    <CVSSScoreSets>
+      <ScoreSetV3>
+        <BaseScoreV3>6.5</BaseScoreV3>
+        <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N</VectorV3>
+      </ScoreSetV3>
+    </CVSSScoreSets>
+  </Vulnerability>
+</cvrfdoc>

--- a/suse/cvrfcve/testdata/cvrfcve/cvrf-CVE-2014-6271.xml
+++ b/suse/cvrfcve/testdata/cvrfcve/cvrf-CVE-2014-6271.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cvrfdoc xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/cvrf">
+  <DocumentTitle xml:lang="en">CVE-2014-6271</DocumentTitle>
+  <DocumentTracking>
+    <Identification>
+      <ID>SUSE CVE-2014-6271</ID>
+    </Identification>
+    <Status>Final</Status>
+    <Version>1</Version>
+    <RevisionHistory>
+      <Revision>
+        <Number>1</Number>
+        <Date>2014-09-24T16:00:00Z</Date>
+        <Description>current</Description>
+      </Revision>
+    </RevisionHistory>
+    <InitialReleaseDate>2014-09-24T16:00:00Z</InitialReleaseDate>
+    <CurrentReleaseDate>2014-09-24T16:00:00Z</CurrentReleaseDate>
+  </DocumentTracking>
+  <DocumentNotes>
+    <Note Title="CVE" Type="Summary" Ordinal="1" xml:lang="en">CVE-2014-6271</Note>
+  </DocumentNotes>
+  <ProductTree xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/prod">
+    <Branch Type="Product Family" Name="SUSE Linux Enterprise Server 11">
+      <Branch Type="Product Name" Name="SUSE Linux Enterprise Server 11">
+        <FullProductName ProductID="SUSE Linux Enterprise Server 11" CPE="cpe:/o:suse:sles:11"/>
+      </Branch>
+    </Branch>
+  </ProductTree>
+  <Vulnerability xmlns="http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln" Ordinal="1">
+    <Notes>
+      <Note Title="Vulnerability Description" Type="General" Ordinal="1" xml:lang="en">GNU Bash through 4.3 processes trailing strings after function definitions in the values of environment variables ("Shellshock").</Note>
+    </Notes>
+    <CVE>CVE-2014-6271</CVE>
+    <ProductStatuses>
+      <Status Type="Fixed">
+        <ProductID>SUSE Linux Enterprise Server 11:bash-3.2-147.14.1</ProductID>
+      </Status>
+    </ProductStatuses>
+    <Threats>
+      <Threat Type="Impact">
+        <Description>critical</Description>
+      </Threat>
+    </Threats>
+    <CVSSScoreSets>
+      <ScoreSetV2>
+        <BaseScoreV2>5.1</BaseScoreV2>
+        <VectorV2>AV:N/AC:H/Au:N/C:P/I:P/A:P</VectorV2>
+      </ScoreSetV2>
+      <ScoreSetV3>
+        <BaseScoreV3>9.8</BaseScoreV3>
+        <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</VectorV3>
+      </ScoreSetV3>
+    </CVSSScoreSets>
+    <References>
+      <Reference Type="Self">
+        <URL>https://www.suse.com/security/cve/CVE-2014-6271/</URL>
+        <Description>CVE-2014-6271</Description>
+      </Reference>
+    </References>
+  </Vulnerability>
+</cvrfdoc>

--- a/suse/cvrfcve/testdata/golden/CVE-1234-12345.json
+++ b/suse/cvrfcve/testdata/golden/CVE-1234-12345.json
@@ -1,0 +1,19 @@
+{
+  "Title": "CVE-1234-12345",
+  "Tracking": {
+    "ID": "SUSE CVE-1234-12345"
+  },
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-1234-12345",
+      "CVSSScoreSets": {
+        "ScoreSetV3": [
+          {
+            "BaseScoreV3": "6.5",
+            "VectorV3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/suse/cvrfcve/testdata/golden/CVE-2014-6271.json
+++ b/suse/cvrfcve/testdata/golden/CVE-2014-6271.json
@@ -1,0 +1,39 @@
+{
+  "Title": "CVE-2014-6271",
+  "Tracking": {
+    "ID": "SUSE CVE-2014-6271",
+    "InitialReleaseDate": "2014-09-24T16:00:00Z",
+    "CurrentReleaseDate": "2014-09-24T16:00:00Z"
+  },
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2014-6271",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "critical"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-6271/",
+          "Description": "CVE-2014-6271"
+        }
+      ],
+      "CVSSScoreSets": {
+        "ScoreSetV2": [
+          {
+            "BaseScoreV2": "5.1",
+            "VectorV2": "AV:N/AC:H/Au:N/C:P/I:P/A:P"
+          }
+        ],
+        "ScoreSetV3": [
+          {
+            "BaseScoreV3": "9.8",
+            "VectorV3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/suse/cvrfcve/types.go
+++ b/suse/cvrfcve/types.go
@@ -1,0 +1,45 @@
+package cvrfcve
+
+type Cvrf struct {
+	Title           string           `xml:"DocumentTitle"`
+	Tracking        DocumentTracking `xml:"DocumentTracking"`
+	Vulnerabilities []Vulnerability  `xml:"Vulnerability"`
+}
+
+type DocumentTracking struct {
+	ID                 string `xml:"Identification>ID"`
+	InitialReleaseDate string `xml:"InitialReleaseDate" json:",omitempty"`
+	CurrentReleaseDate string `xml:"CurrentReleaseDate" json:",omitempty"`
+}
+
+type Vulnerability struct {
+	CVE           string        `xml:"CVE"`
+	Threats       []Threat      `xml:"Threats>Threat" json:",omitempty"`
+	References    []Reference   `xml:"References>Reference" json:",omitempty"`
+	CVSSScoreSets CVSSScoreSets `xml:"CVSSScoreSets" json:",omitempty"`
+}
+
+type Threat struct {
+	Type     string `xml:"Type,attr"`
+	Severity string `xml:"Description"`
+}
+
+type Reference struct {
+	URL         string `xml:"URL"`
+	Description string `xml:"Description"`
+}
+
+type CVSSScoreSets struct {
+	ScoreSetV2 []ScoreSetV2 `xml:"ScoreSetV2" json:",omitempty"`
+	ScoreSetV3 []ScoreSetV3 `xml:"ScoreSetV3" json:",omitempty"`
+}
+
+type ScoreSetV2 struct {
+	BaseScoreV2 string `xml:"BaseScoreV2" json:",omitempty"`
+	VectorV2    string `xml:"VectorV2" json:",omitempty"`
+}
+
+type ScoreSetV3 struct {
+	BaseScoreV3 string `xml:"BaseScoreV3" json:",omitempty"`
+	VectorV3    string `xml:"VectorV3" json:",omitempty"`
+}


### PR DESCRIPTION
The cvrf feed which contains the advisories are missing the scores of the cve's data related to the advisory, so to fetch the cve data we're using cvrf-cve feed provided by the suse to get the cve details.

The new directory is 221MB

The regular SUSE CVRF advisory feed at `http://ftp.suse.com/pub/projects/security/cvrf/` (consumed by the existing `suse-cvrf` target) does not publish CVSS v3 / v4 scores — only the v2 vector, where present. SUSE exposes the v3/v4 scores in a separate per-CVE CVRF feed at `http://ftp.suse.com/pub/projects/security/cvrf-cve/`, and this PR adds a new `suse-cvrf-cve` target that mirrors those documents into `cvrf/suse-cves/<year>/CVE-<id>.json` so downstream consumers (e.g. trivy-db) can look up the scores.

- **New `suse/cvrfarchive` package** that encapsulates the download / decompress / tar-walk logic. Both feeds (`suse/cvrf` and `suse/cvrfcve`) now share this code; the duplicated archive plumbing in `suse/cvrf/cvrf.go` has been removed.
- **New `suse/cvrfcve` package** that registers as `suse-cvrf-cve` (directory renamed from `suse/cvrf-cve` to drop the hyphen, matching Go package conventions).
- The persisted schema is trimmed to the fields needed for CVSS lookup: `Title`, `Tracking.{ID,InitialReleaseDate,CurrentReleaseDate}`, and per-vulnerability `CVE` / `Threats` / `References` / `CVSSScoreSets`. The bulky `ProductTree`, `ProductStatuses`, `DocumentNotes` and `RevisionHistory` blocks are dropped, which keeps the persisted JSON tree small (the upstream archive is ~250 MB compressed / ~10 GB uncompressed; trimming brings the resulting `cvrf/suse-cves/` tree down by roughly two orders of magnitude).
- **Single archive download.** Fetching the per-CVE files individually (≈80k requests at the previous 5/s budget) made the GitHub-hosted job exceed the 6h limit. The new code downloads `cvrf-cve.tar.bz2` once and stream-extracts it, mirroring the fix applied to `suse-cvrf` in #437.
- `main.go` registers the new target and `README.md` documents it. `update.yml` gains a single `SUSE CVE CVRF` step.
