### PR TITLE
ci: switch to ubuntu-2404-4core runner for vuln-list update workflows

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     name: Update vuln-list-redhat
-    runs-on: ubuntu-2404-2core
+    runs-on: ubuntu-2404-4core
     permissions:
       contents: read
     env:

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     name: Update vuln-list-redhat
-    runs-on: ubuntu-2404-4core
+    runs-on: ubuntu-2404-2core
     permissions:
       contents: read
     env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     name: Update repo vuln-list
-    runs-on: ubuntu-2404-2core
+    runs-on: ubuntu-2404-4core
     permissions:
       contents: read
     env:


### PR DESCRIPTION
## Summary
- Bump runner from `ubuntu-2404-2core` to `ubuntu-2404-4core` in `update.yml`
- The 2-core runner runs out of resources during vuln-list updates, causing job failures

## Related failures
- https://github.com/aquasecurity/vuln-list-update/actions/runs/24176387674/job/70558685207