### PR TITLE
ci: free disk space before vuln-list-redhat checkout

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -14,18 +14,16 @@ jobs:
       VULN_LIST_DIR: "vuln-list-redhat"
     steps:
     # vuln-list-redhat dir uses more than 20GB of storage
-    # Disabled: ubuntu-2404-2core runner has enough disk space.
-    # - name: Maximize build space
-    #   uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
-    #   with:
-    #     remove-android: 'true'
-    #     remove-dotnet: 'true'
-    #     remove-haskell: 'true'
-    #     remove-codeql: 'true'
-    #     remove-docker-images: 'true'
-    #     remove-large-packages: 'true'
-    #     remove-cached-tools: 'true'
-    #     remove-swapfile: 'true'
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force > /dev/null
+        df -h
 
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Summary
- Replace the commented-out third-party action (`AdityaGarg8/remove-unwanted-software`) with simple `rm -rf` commands to free disk space
- Removes .NET, Android SDK, GHC, Boost, CodeQL, and unused Docker images (~30GB)
- Fixes disk space errors during vuln-list-redhat checkout

Ref: https://github.com/aquasecurity/vuln-list-update/actions/runs/24176249995

## Test
https://github.com/aquasecurity/vuln-list-update/actions/runs/24322011213 ✅