### PR TITLE
fix(utils): prevent panic on closed channel in FetchConcurrently

### DIFF
--- a/openeuler/openeuler.go
+++ b/openeuler/openeuler.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/cheggaaa/pb"
@@ -81,7 +82,7 @@ func (c Config) Update() error {
 }
 
 func (c Config) update(year string, urls []string) error {
-	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry)
+	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry, 10*time.Minute)
 	if err != nil {
 		log.Printf("failed to fetch CVRF data from repo.openEuler.org, err: %s", err)
 	}

--- a/redhat/securitydataapi/redhat.go
+++ b/redhat/securitydataapi/redhat.go
@@ -100,7 +100,7 @@ func listAllRedhatCves(after, before string, wait int) (entries []RedhatEntry, e
 func retrieveRedhatCveDetails(urls []string) (map[string]*RedhatCVEJSON, error) {
 	cves := map[string]*RedhatCVEJSON{}
 
-	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry)
+	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry, 10*time.Minute)
 	if err != nil {
 		log.Printf("failed to fetch cve data from RedHat. err: %s", err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -147,13 +147,10 @@ func fetchURL(url string, headers map[string]string) ([]byte, error) {
 }
 
 // FetchConcurrently fetches concurrently
-func FetchConcurrently(urls []string, concurrency, wait, retry int) (responses [][]byte, err error) {
+func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time.Duration) (responses [][]byte, err error) {
 	reqChan := make(chan string, len(urls))
 	resChan := make(chan []byte, len(urls))
 	errChan := make(chan error, len(urls))
-	defer close(reqChan)
-	defer close(resChan)
-	defer close(errChan)
 
 	go func() {
 		for _, url := range urls {
@@ -178,20 +175,19 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int) (responses [
 	bar.Finish()
 
 	var errs []error
-	timeout := time.After(10 * 60 * time.Second)
+	timeoutCh := time.After(timeout)
 	for range urls {
 		select {
 		case res := <-resChan:
 			responses = append(responses, res)
 		case err := <-errChan:
 			errs = append(errs, err)
-		case <-timeout:
+		case <-timeoutCh:
 			return nil, xerrors.New("Timeout Fetching URL")
 		}
 	}
-	if 0 < len(errs) {
+	if len(errs) > 0 {
 		return responses, fmt.Errorf("%s", errs)
-
 	}
 	return responses, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -12,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	pb "github.com/cheggaaa/pb/v3"
@@ -80,11 +82,13 @@ func Write(filePath string, data interface{}) error {
 	return nil
 }
 
-// GenWorkers generate workders
-func GenWorkers(num, wait int) chan<- func() {
+// GenWorkers generate workers
+func GenWorkers(num, wait int, wg *sync.WaitGroup) chan<- func() {
 	tasks := make(chan func())
-	for i := 0; i < num; i++ {
+	for range num {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for f := range tasks {
 				f()
 				time.Sleep(time.Duration(wait) * time.Second)
@@ -158,8 +162,10 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 		}
 	}()
 
+	timeoutCh := time.After(timeout)
 	bar := pb.StartNew(len(urls))
-	tasks := GenWorkers(concurrency, wait)
+	var wg sync.WaitGroup
+	tasks := GenWorkers(concurrency, wait, &wg)
 	for range urls {
 		tasks <- func() {
 			url := <-reqChan
@@ -173,21 +179,31 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 		bar.Increment()
 	}
 	bar.Finish()
+	close(tasks)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-timeoutCh:
+		return nil, xerrors.New("Timeout Fetching URL")
+	}
 
 	var errs []error
-	timeoutCh := time.After(timeout)
 	for range urls {
 		select {
 		case res := <-resChan:
 			responses = append(responses, res)
 		case err := <-errChan:
 			errs = append(errs, err)
-		case <-timeoutCh:
-			return nil, xerrors.New("Timeout Fetching URL")
 		}
 	}
 	if len(errs) > 0 {
-		return responses, fmt.Errorf("%s", errs)
+		return responses, errors.Join(errs...)
 	}
 	return responses, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -167,7 +167,7 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 	var wg sync.WaitGroup
 	tasks := GenWorkers(concurrency, wait, &wg)
 	for range urls {
-		tasks <- func() {
+		fn := func() {
 			url := <-reqChan
 			res, err := FetchURL(url, "", retry)
 			if err != nil {
@@ -175,6 +175,12 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 				return
 			}
 			resChan <- res
+		}
+		select {
+		case tasks <- fn:
+		case <-timeoutCh:
+			close(tasks)
+			return nil, xerrors.New("Timeout Fetching URL")
 		}
 		bar.Increment()
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -162,7 +162,8 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 		}
 	}()
 
-	timeoutCh := time.After(timeout)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	bar := pb.StartNew(len(urls))
 	var wg sync.WaitGroup
 	tasks := GenWorkers(concurrency, wait, &wg)
@@ -178,7 +179,7 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 		}
 		select {
 		case tasks <- fn:
-		case <-timeoutCh:
+		case <-timer.C:
 			close(tasks)
 			return nil, xerrors.New("Timeout Fetching URL")
 		}
@@ -195,7 +196,7 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 
 	select {
 	case <-done:
-	case <-timeoutCh:
+	case <-timer.C:
 		return nil, xerrors.New("Timeout Fetching URL")
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -152,6 +152,10 @@ func fetchURL(url string, headers map[string]string) ([]byte, error) {
 
 // FetchConcurrently fetches concurrently
 func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time.Duration) (responses [][]byte, err error) {
+	// Each URL pushes at most one value into each channel, so buffering to
+	// len(urls) means writers never block. They are intentionally not closed:
+	// receivers read a bounded number of values (no range), and closing while
+	// workers are still sending would panic. GC reclaims them once unreferenced.
 	reqChan := make(chan string, len(urls))
 	resChan := make(chan []byte, len(urls))
 	errChan := make(chan error, len(urls))
@@ -180,6 +184,9 @@ func FetchConcurrently(urls []string, concurrency, wait, retry int, timeout time
 		select {
 		case tasks <- fn:
 		case <-timer.C:
+			// Stop dispatching and return without waiting: workers already
+			// running keep fetching in the background until they finish their
+			// current request, then exit on the closed tasks channel.
 			close(tasks)
 			return nil, xerrors.New("Timeout Fetching URL")
 		}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,45 @@
+package utils_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/vuln-list-update/utils"
+)
+
+func TestFetchConcurrently_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1 * time.Second)
+		w.Write([]byte("data"))
+	}))
+	defer srv.Close()
+
+	urls := []string{srv.URL, srv.URL, srv.URL}
+
+	// should not panic when timeout fires before workers finish
+	require.NotPanics(t, func() {
+		_, err := utils.FetchConcurrently(urls, 2, 0, 0, 100*time.Millisecond)
+		assert.Error(t, err)
+	})
+}
+
+func TestFetchConcurrently_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	urls := []string{srv.URL, srv.URL, srv.URL}
+
+	responses, err := utils.FetchConcurrently(urls, 2, 0, 0, 10*time.Second)
+	require.NoError(t, err)
+	assert.Len(t, responses, 3)
+	for _, r := range responses {
+		assert.Equal(t, []byte("ok"), r)
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -12,34 +12,54 @@ import (
 	"github.com/aquasecurity/vuln-list-update/utils"
 )
 
-func TestFetchConcurrently_Timeout(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(1 * time.Second)
-		w.Write([]byte("data"))
-	}))
-	defer srv.Close()
+func TestFetchConcurrently(t *testing.T) {
+	const body = "ok"
 
-	urls := []string{srv.URL, srv.URL, srv.URL}
+	tests := []struct {
+		name        string
+		serverDelay time.Duration
+		timeout     time.Duration
+		wantErr     bool
+	}{
+		{
+			name:        "timeout fires before workers finish",
+			serverDelay: 1 * time.Second,
+			timeout:     100 * time.Millisecond,
+			wantErr:     true,
+		},
+		{
+			name:    "all urls fetched successfully",
+			timeout: 10 * time.Second,
+		},
+	}
 
-	// should not panic when timeout fires before workers finish
-	require.NotPanics(t, func() {
-		_, err := utils.FetchConcurrently(urls, 2, 0, 0, 100*time.Millisecond)
-		assert.Error(t, err)
-	})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(tt.serverDelay)
+				w.Write([]byte(body))
+			}))
+			defer srv.Close()
 
-func TestFetchConcurrently_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("ok"))
-	}))
-	defer srv.Close()
+			urls := []string{srv.URL, srv.URL, srv.URL}
 
-	urls := []string{srv.URL, srv.URL, srv.URL}
+			var responses [][]byte
+			var err error
+			// should not panic even when the timeout fires before workers finish
+			require.NotPanics(t, func() {
+				responses, err = utils.FetchConcurrently(urls, 2, 0, 0, tt.timeout)
+			})
 
-	responses, err := utils.FetchConcurrently(urls, 2, 0, 0, 10*time.Second)
-	require.NoError(t, err)
-	assert.Len(t, responses, 3)
-	for _, r := range responses {
-		assert.Equal(t, []byte("ok"), r)
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "Timeout Fetching URL")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, responses, len(urls))
+			for _, r := range responses {
+				assert.Equal(t, []byte(body), r)
+			}
+		})
 	}
 }


### PR DESCRIPTION
On timeout, deferred channel closing fired while workers were  still writing. Removed defer closes (buffered channels, GC handles cleanup) and made timeout configurable for testability.

Additional improvements based on review:                                                                                     
  - Add WaitGroup to `GenWorkers` for clean worker shutdown                                                                      
  - Enforce timeout during task dispatch via select to stop sending new tasks early                                            
  - Replace `time.After` with `time.NewTimer` + `defer Stop` to release timer resources early

Before:
```bash
❯ go test ./utils/ -run TestFetchConcurrently -v -timeout 30s
PASS: TestFetchConcurrently_Timeout (2.00s)
panic: send on closed channel

goroutine 69 [running]:
github.com/aquasecurity/vuln-list-update/utils.FetchConcurrently.func2()
        /Users/nikita/projects/vuln-list-update/utils/utils.go:174 +0xa4
github.com/aquasecurity/vuln-list-update/utils.GenWorkers.func1()
        /Users/nikita/projects/vuln-list-update/utils/utils.go:89 +0x3c
created by github.com/aquasecurity/vuln-list-update/utils.GenWorkers in goroutine 65
        /Users/nikita/projects/vuln-list-update/utils/utils.go:87 +0x4c
FAIL    github.com/aquasecurity/vuln-list-update/utils  2.898s
FAIL
```

After:
```bash
❯ go test ./utils/ -run TestFetchConcurrently -v -timeout 30s
=== RUN   TestFetchConcurrently_Timeout
PASS: TestFetchConcurrently_Timeout (2.00s)
=== RUN   TestFetchConcurrently_Success
--- PASS: TestFetchConcurrently_Success (0.00s)
PASS
ok      github.com/aquasecurity/vuln-list-update/utils  2.693s
```