### PR TITLE
ci: switch from PAT to GitHub App installation token

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -27,7 +27,7 @@ jobs:
       id: vuln-list-debian-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+        client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -27,7 +27,7 @@ jobs:
       id: vuln-list-debian-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -23,11 +23,20 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Generate token for vuln-list-debian
+      id: vuln-list-debian-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ env.VULN_LIST_DIR }}
+
     - name: Check out vuln-list-debian repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.repository_owner }}/${{ env.VULN_LIST_DIR }}
-        token: ${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}
+        token: ${{ steps.vuln-list-debian-token.outputs.token }}
         path: ${{ env.VULN_LIST_DIR }}
         persist-credentials: true # update.sh runs git push
 

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -27,7 +27,7 @@ jobs:
       id: vuln-list-nvd-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+        client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -23,11 +23,20 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Generate token for vuln-list-nvd
+      id: vuln-list-nvd-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ env.VULN_LIST_DIR }}
+
     - name: Check out vuln-list-nvd repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.repository_owner }}/${{ env.VULN_LIST_DIR }}
-        token: ${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}
+        token: ${{ steps.vuln-list-nvd-token.outputs.token }}
         path: ${{ env.VULN_LIST_DIR }}
         persist-credentials: true # update.sh runs git push
 

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -27,7 +27,7 @@ jobs:
       id: vuln-list-nvd-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -35,11 +35,20 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Generate token for vuln-list-redhat
+      id: vuln-list-redhat-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ env.VULN_LIST_DIR }}
+
     - name: Check out vuln-list-redhat repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.repository_owner }}/${{ env.VULN_LIST_DIR }}
-        token: ${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}
+        token: ${{ steps.vuln-list-redhat-token.outputs.token }}
         path: ${{ env.VULN_LIST_DIR }}
         persist-credentials: true # update.sh runs git push
 
@@ -56,12 +65,44 @@ jobs:
       run: ./scripts/update.sh redhat-oval "Red Hat OVAL v2"
 
     - if: always()
-      name: Red Hat Security Data API
-      run: ./scripts/update.sh redhat "Red Hat Security Data API"
-
-    - if: always()
       name: Red Hat CSAF VEX
       run: ./scripts/update.sh redhat-csaf-vex "Red Hat CSAF VEX"
+
+    # Red Hat Security Data API takes ~1.5h, longer than the 1h GitHub App installation token TTL.
+    # Split into fetch + refresh-token + push so the push uses a fresh token.
+    # Must run last in this job: subsequent steps would inherit the stale initial token.
+    - if: always()
+      id: redhat-security-data-fetch
+      name: Red Hat Security Data API (fetch)
+      run: |
+        ./vuln-list-update -vuln-list-dir "$VULN_LIST_DIR" -target redhat
+        if [[ -n $(git -C "$VULN_LIST_DIR" status --porcelain) ]]; then
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - if: steps.redhat-security-data-fetch.outputs.has_changes == 'true'
+      name: Refresh token for Red Hat Security Data API push
+      id: vuln-list-redhat-push-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ env.VULN_LIST_DIR }}
+
+    - if: steps.vuln-list-redhat-push-token.conclusion == 'success'
+      name: Red Hat Security Data API (push)
+      env:
+        GH_APP_TOKEN: ${{ steps.vuln-list-redhat-push-token.outputs.token }}
+        REPO_OWNER: ${{ github.repository_owner }}
+      run: |
+        cd "$VULN_LIST_DIR"
+        # actions/checkout writes an extraheader that overrides URL credentials, drop it so the refreshed token is used
+        git config --local --unset-all http.https://github.com/.extraheader || true
+        git remote set-url origin "https://x-access-token:${GH_APP_TOKEN}@github.com/${REPO_OWNER}/${VULN_LIST_DIR}.git"
+        git add .
+        git commit -m "Red Hat Security Data API"
+        git push
 
     - name: Microsoft Teams Notification
       uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -39,7 +39,7 @@ jobs:
       id: vuln-list-redhat-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}
@@ -94,7 +94,7 @@ jobs:
       id: vuln-list-redhat-push-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -81,6 +81,8 @@ jobs:
         ./vuln-list-update -vuln-list-dir "$VULN_LIST_DIR" -target redhat
         if [[ -n $(git -C "$VULN_LIST_DIR" status --porcelain) ]]; then
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No changes — refresh and push will be skipped"
         fi
 
     - if: steps.redhat-security-data-fetch.outputs.has_changes == 'true'

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -78,7 +78,11 @@ jobs:
       id: redhat-security-data-fetch
       name: Red Hat Security Data API (fetch)
       run: |
-        ./vuln-list-update -vuln-list-dir "$VULN_LIST_DIR" -target redhat
+        ./vuln-list-update -vuln-list-dir "$VULN_LIST_DIR" -target redhat || {
+          echo "[Err] Revert changes" >&2
+          cd "$VULN_LIST_DIR" && git reset --hard HEAD
+          exit 1
+        }
         if [[ -n $(git -C "$VULN_LIST_DIR" status --porcelain) ]]; then
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -39,7 +39,7 @@ jobs:
       id: vuln-list-redhat-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+        client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}
@@ -94,7 +94,7 @@ jobs:
       id: vuln-list-redhat-push-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+        client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ env.VULN_LIST_DIR }}

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Compile vuln-list-update
       run: go build -o vuln-list-update .
 
+    # OVALv2 (~4 min) and CSAF VEX (~1 min) push using the initial job-level token; both must complete within its 1h TTL.
     - if: always()
       name: Red Hat OVALv2
       run: ./scripts/update.sh redhat-oval "Red Hat OVAL v2"
@@ -70,7 +71,9 @@ jobs:
 
     # Red Hat Security Data API takes ~1.5h, longer than the 1h GitHub App installation token TTL.
     # Split into fetch + refresh-token + push so the push uses a fresh token.
-    # Must run last in this job: subsequent steps would inherit the stale initial token.
+    # Must run last in this job: by the time the fetch completes the initial token is dead,
+    # and the push step rewrites git auth state in the workdir (drops extraheader, sets origin
+    # URL with the refreshed token), so any source running after this would fail to push.
     - if: always()
       id: redhat-security-data-fetch
       name: Red Hat Security Data API (fetch)

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -21,18 +21,27 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
 
+    - name: Generate token for vuln-list
+      id: vuln-list-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: vuln-list
+
     - name: Clone a shallow repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.repository_owner }}/vuln-list
-        token: ${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}
+        token: ${{ steps.vuln-list-token.outputs.token }}
         path: vuln-list
         fetch-depth: 2000
-        persist-credentials: false
+        # extraheader from checkout authenticates the push below; git filter-repo removes the origin remote but leaves the http.extraheader config intact
 
     - name: Squash and push
       run: |
         cd vuln-list
         git replace -f --graft $(git rev-list --max-parents=0 HEAD)
         git filter-repo --force
-        git push --force --set-upstream https://${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}@github.com/${{ github.repository_owner }}/vuln-list.git main
+        git push --force --set-upstream "https://github.com/${{ github.repository_owner }}/vuln-list.git" main

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -37,7 +37,9 @@ jobs:
         token: ${{ steps.vuln-list-token.outputs.token }}
         path: vuln-list
         fetch-depth: 2000
-        # extraheader from checkout authenticates the push below; git filter-repo removes the origin remote but leaves the http.extraheader config intact
+        # extraheader from checkout authenticates the push below
+        # (git filter-repo drops the origin remote but leaves http.extraheader intact)
+        persist-credentials: true
 
     - name: Squash and push
       run: |

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -25,7 +25,7 @@ jobs:
       id: vuln-list-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: vuln-list

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -25,7 +25,7 @@ jobs:
       id: vuln-list-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+        client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
         private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: vuln-list

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
         id: vuln-list-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
+          client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: vuln-list

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,11 +23,20 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Generate token for vuln-list
+        id: vuln-list-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+          private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: vuln-list
+
       - name: Check out vuln-list repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: ${{ github.repository_owner }}/vuln-list
-          token: ${{ secrets.SA_GH_VULN_LIST_UPDATE_TOKEN }}
+          token: ${{ steps.vuln-list-token.outputs.token }}
           path: ${{ env.VULN_LIST_DIR }}
           persist-credentials: true # update.sh runs git push
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
         id: vuln-list-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_ID }}
+          app-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: vuln-list


### PR DESCRIPTION
## Description

Replace the long-lived PAT (`SA_GH_VULN_LIST_UPDATE_TOKEN`) with short-lived installation tokens minted from a GitHub App via [`actions/create-github-app-token`][action] (`v3.1.1`, pinned by SHA). App is authenticated via Client ID (`app-id` input is deprecated upstream, [we use `client-id`][client-id-doc]).

App credentials: `SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID` + `SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY`.

Tokens are scoped to the single repository each workflow checks out: `vuln-list`, `vuln-list-redhat`, `vuln-list-nvd`, `vuln-list-debian`.

[action]: https://github.com/actions/create-github-app-token
[client-id-doc]: https://github.com/actions/create-github-app-token/blob/1b10c78c7865c340bc4f6099eb2f838309f1e8c3/action.yml

## Special case: Red Hat Security Data API

`Red Hat Security Data API` alone takes ~1.5h — longer than the 1h installation token TTL. The redhat job is restructured so this source runs last, and is split into:

1. **Fetch** — runs `vuln-list-update`; sets `has_changes=true` if there's anything to push.
2. **Refresh token** — generates a fresh installation token; skipped if no changes.
3. **Push** — drops the now-stale extraheader written by `actions/checkout`, sets `origin` URL with the refreshed token, then pushes.

Red Hat OVALv2 (~4 min) and Red Hat CSAF VEX (~1 min) keep using the initial job-level token — both fit within its 1h TTL.

## Required admin actions

- [x] **Add secrets:** `SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID`, `SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY`.
- [ ] **Remove (after merge):** `SA_GH_VULN_LIST_UPDATE_TOKEN`.

## Test runs

Verified end-to-end on a fork (`DmitriyLewen/vuln-list-update`) using `ubuntu-24.04` runner, pointing to forked `vuln-list-*` repos.

| Workflow | Scenario | Status | Run |
|---|---|---|---|
| nvd | happy path | ✅ | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25546309907 |
| debian | happy path | ✅ | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25546311196 |
| update (all 17 sources) | happy path | ⚠️ | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25546312301 |
| redhat (full ~2h) | happy path: OVALv2 → CSAF VEX → Security Data API split | ✅ | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25547930623 |
| redhat | stub: fetch succeeds with no workdir changes → refresh + push skipped | ✅ | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25546319814 |
| redhat | stub: `vuln-list-update` exits 1 → refresh + push skipped (failure is the test) | ❌ (expected) | https://github.com/DmitriyLewen/vuln-list-update/actions/runs/25547167304 |

> ⚠️ `update.yml` failure is unrelated to this migration: only the `openEuler CVE` step failed with `Timeout Fetching URL` from `repo.openEuler.org` (transient external API). All 16 other sources, the App-token generation, and the pushes succeeded.