### PR TITLE
fix: don't drop data on FetchConcurrently timeout/error

### DIFF
--- a/openeuler/openeuler.go
+++ b/openeuler/openeuler.go
@@ -84,7 +84,7 @@ func (c Config) Update() error {
 func (c Config) update(year string, urls []string) error {
 	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry, 10*time.Minute)
 	if err != nil {
-		return xerrors.Errorf("failed to fetch CVRF data from repo.openEuler.org: %w", err)
+		return xerrors.Errorf("failed to fetch CVRF data from repo.openeuler.org: %w", err)
 	}
 
 	var cvrfs []Cvrf

--- a/openeuler/openeuler.go
+++ b/openeuler/openeuler.go
@@ -84,7 +84,7 @@ func (c Config) Update() error {
 func (c Config) update(year string, urls []string) error {
 	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry, 10*time.Minute)
 	if err != nil {
-		log.Printf("failed to fetch CVRF data from repo.openEuler.org, err: %s", err)
+		return xerrors.Errorf("failed to fetch CVRF data from repo.openEuler.org: %w", err)
 	}
 
 	var cvrfs []Cvrf

--- a/redhat/securitydataapi/redhat.go
+++ b/redhat/securitydataapi/redhat.go
@@ -102,7 +102,7 @@ func retrieveRedhatCveDetails(urls []string) (map[string]*RedhatCVEJSON, error) 
 
 	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry, 30*time.Minute)
 	if err != nil {
-		log.Printf("failed to fetch cve data from RedHat. err: %s", err)
+		return nil, xerrors.Errorf("failed to fetch cve data from RedHat: %w", err)
 	}
 
 	for _, cveJSON := range cveJSONs {

--- a/redhat/securitydataapi/redhat.go
+++ b/redhat/securitydataapi/redhat.go
@@ -100,7 +100,7 @@ func listAllRedhatCves(after, before string, wait int) (entries []RedhatEntry, e
 func retrieveRedhatCveDetails(urls []string) (map[string]*RedhatCVEJSON, error) {
 	cves := map[string]*RedhatCVEJSON{}
 
-	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry, 10*time.Minute)
+	cveJSONs, err := utils.FetchConcurrently(urls, concurrency, wait, retry, 30*time.Minute)
 	if err != nil {
 		log.Printf("failed to fetch cve data from RedHat. err: %s", err)
 	}


### PR DESCRIPTION
## Description

After #444 the timer in `utils.FetchConcurrently` was moved to start **before** the dispatch loop, so it now bounds the whole fetch operation instead of only the drain phase. As a result the Red Hat Security Data API fetch for the heavy years (e.g. 2025 has ~7.9k CVEs, ~15 min) no longer fits inside the 10-minute timeout and hits `Timeout Fetching URL`.

On timeout `FetchConcurrently` returns `nil`, and since `retrieveRedhatCveDetails` only logged the error, `Update()` finished successfully while writing no data for those years. Because `Update()` removes the `api` directory up front, this was committed as a **mass deletion** of CVE data to `vuln-list-redhat` (e.g. [`fde265e`](https://github.com/aquasecurity/vuln-list-redhat/commit/fde265e768b8945152b37eb08d8fcbde6a2d8bcc) — 14064 files removed).

## Changes

`redhat/securitydataapi`:
- Bump the per-year CVE-details fetch timeout `10m → 30m`, which comfortably covers the current heavy years.
- Return the fetch error instead of logging it, so a failed fetch aborts the run (CI then reverts the working tree) instead of pushing data loss.

`openeuler`:
- Return the fetch error instead of logging it. openEuler doesn't wipe its output directory up front, so this never caused a mass deletion — but after #444 a timed-out fetch was silently skipped, leaving stale CVRF data; failing the run surfaces it instead.

> [!NOTE]
> `FetchConcurrently` returns an error on **any** failure (incl. a single per-CVE failure after retries), not only on timeout — so a transient failure now aborts the whole `Update` instead of saving a partial dataset. This is intentional: a partial fetch combined with the up-front `RemoveAll` is exactly what produces a mass deletion, so failing the run (and letting CI `git reset --hard`) is the safe choice. A more tolerant design (distinguish timeout from per-CVE flakiness, or temp dir + atomic swap instead of `RemoveAll`) is left as follow-up.

## Why the 10m timeout used to be effectively a no-op

`FetchConcurrently` runs a fixed pool of `concurrency` (= 10) workers reading from an **unbuffered** `tasks` channel, while `resChan`/`errChan` are buffered to `len(urls)`:

- The dispatch loop `for range urls { tasks <- fn }` blocks whenever all 10 workers are busy, so it advances only as fast as the workers drain it. Dispatching all URLs therefore takes ~the entire fetch duration, and results stream into the buffered channels without ever blocking the workers.

**Before #444** the timer was created *after* the dispatch loop, so its 10-minute budget covered only the final collection/drain — i.e. waiting for the last in-flight batch (the ~10 still-running goroutines) to finish. Practically all of the fetching happened earlier, during the **untimed** dispatch loop. So a year that takes 12–15 min to fetch never tripped the 10-minute timer: almost all of that time was spent dispatching, and the drain that the timer actually guarded was near-instant. In effect the timeout only ever applied to the last ~10 goroutines.

**After #444** the timer is created *before* the dispatch loop and is selected on inside dispatch (and again on the `wg.Wait`). Now the 10-minute budget bounds the **whole** operation — dispatch + fetch + drain — so the heavy years exceed it and return `Timeout Fetching URL`.

```go
// before (#444 parent): time.After(...) created AFTER the dispatch loop →
// only the final drain (the last ~10 in-flight goroutines) is under the 10m budget
for range urls {
    tasks <- func() { ... } // blocks while all 10 workers are busy → this loop ≈ the whole fetch (untimed)
}
timeout := time.After(10 * 60 * time.Second)
for range urls {
    select {
    case res := <-resChan: ...
    case err := <-errChan: ...
    case <-timeout: // only fires if that last batch can't drain within 10m
        return nil, xerrors.New("Timeout Fetching URL")
    }
}

// after (#444): timer created BEFORE the dispatch loop and checked during dispatch →
// the whole fetch is under the 10m budget
timer := time.NewTimer(timeout)
for range urls {
    select {
    case tasks <- fn:
    case <-timer.C:
        close(tasks)
        return nil, xerrors.New("Timeout Fetching URL")
    }
}
```

## Test runs:
- https://github.com/DmitriyLewen/vuln-list-update/actions/runs/26637232175/job/78500544735