### PR TITLE
fix(openeuler): raise per-year fetch timeout to 30m

### DIFF
--- a/openeuler/openeuler.go
+++ b/openeuler/openeuler.go
@@ -82,7 +82,10 @@ func (c Config) Update() error {
 }
 
 func (c Config) update(year string, urls []string) error {
-	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry, 10*time.Minute)
+	// The largest year holds ~1900 advisories; when repo.openeuler.org is slow
+	// (throughput drops to ~1.6 advisories/sec) fetching it takes ~20 min, so a
+	// 30 min timeout leaves headroom. A shorter limit reverts the whole run.
+	cvrfXmls, err := utils.FetchConcurrently(urls, concurrency, wait, c.Retry, 30*time.Minute)
 	if err != nil {
 		return xerrors.Errorf("failed to fetch CVRF data from repo.openeuler.org: %w", err)
 	}


### PR DESCRIPTION
## Problem
openEuler updates fail with `Timeout Fetching URL` when repo.openeuler.org is slow.
`FetchConcurrently` has a 10m per-year timeout; the largest year (~1900 advisories)
cannot finish in time and the run is reverted. 4 failures in 8 days (06-02, 06-04,
06-09, 06-10), all in the ~08:00 UTC slot.

## Analysis
- Worst-case measured throughput: ~1.6 advisories/sec.
- Largest year (~1900) then needs ~20 min — over the 10m limit.
- Per-request latency stayed ~12s on average (well under any per-request timeout),
  so the bottleneck is overall slowness, not hung connections.

## Fix
Raise the per-year timeout 10m → 30m (~50% headroom over the ~20 min worst case;
matches redhat/securitydataapi which already uses 30m).
