### PR TITLE
fix(nvd): retry transient body-read errors and 524 responses

### DIFF
--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -23,6 +23,11 @@ const (
 	maxResultsPerPage = 2000
 	retryAfter        = 30 * time.Second
 	apiKeyEnvName     = "NVD_API_KEY"
+
+	// statusOriginTimeout is a non-standard Cloudflare status code (524) returned
+	// when the origin server (NVD backend behind the proxy) does not respond in time.
+	// There is no constant for it in net/http.
+	statusOriginTimeout = 524
 )
 
 type Option func(*Updater)
@@ -135,66 +140,86 @@ func (u Updater) saveEntry(interval TimeInterval, startIndex int) (int, error) {
 
 func (u Updater) fetchEntry(url string) (Entry, error) {
 	var entry Entry
-	r, err := u.fetchURL(url)
+	body, err := u.fetchURL(url)
 	if err != nil {
 		return Entry{}, xerrors.Errorf("unable to fetch: %w", err)
-	} else if r == nil {
+	} else if body == nil {
 		return Entry{}, xerrors.Errorf("unable to get entry from %q", url)
 	}
-	defer r.Close()
 
-	if err = json.NewDecoder(r).Decode(&entry); err != nil {
+	if err = json.Unmarshal(body, &entry); err != nil {
 		return Entry{}, xerrors.Errorf("unable to decode response for %q: %w", url, err)
 	}
 	return entry, nil
 }
 
-func (u Updater) fetchURL(url string) (io.ReadCloser, error) {
+func (u Updater) fetchURL(url string) ([]byte, error) {
 	var c http.Client
 	for i := 0; i <= u.retry; i++ {
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		body, wait, err := u.doRequest(&c, url, i)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to build request for %q: %w", url, err)
+			return nil, err
 		}
-		if u.apiKey != "" {
-			req.Header.Set("apiKey", u.apiKey)
+		// A nil body with a nil error means the request should be retried after `wait`.
+		if body != nil {
+			return body, nil
 		}
-
-		resp, err := c.Do(req)
-		if err != nil {
-			slog.Error("Response error. Try to get the entry again.", slog.String("error", err.Error()))
-			continue
-		}
-		switch resp.StatusCode {
-		case http.StatusForbidden, http.StatusTooManyRequests:
-			slog.Error("NVD rate limit. Wait to gain access.")
-			ra := u.retryAfter
-			// NVD returns the `Retry-After` header as 0.
-			// But if they start setting a non-zero value, we can use that duration.
-			if headerRetry := resp.Header.Get("Retry-After"); headerRetry != "0" {
-				hRetry, err := time.ParseDuration(headerRetry)
-				if err == nil {
-					ra = hRetry
-				}
-			}
-			// NVD limits:
-			// Without API key: 5 requests / 30 seconds window
-			// With API key: 50 requests / 30 seconds window
-			time.Sleep(ra)
-			continue
-		case http.StatusServiceUnavailable, http.StatusRequestTimeout, http.StatusBadGateway, http.StatusGatewayTimeout:
-			slog.Error("NVD API is unstable. Try to fetch URL again.", slog.String("status_code", resp.Status))
-			// NVD API works unstable
-			time.Sleep(time.Duration(i) * time.Second)
-			continue
-		case http.StatusOK:
-			return resp.Body, nil
-		default:
-			return nil, xerrors.Errorf("unexpected status code: %s", resp.Status)
-		}
-
+		time.Sleep(wait)
 	}
 	return nil, xerrors.Errorf("unable to fetch url. Retry limit exceeded.")
+}
+
+// doRequest performs a single NVD request attempt and closes the response body
+// before returning. It returns the response body on success. A nil body with a
+// nil error means the request should be retried after waiting for `wait`.
+func (u Updater) doRequest(c *http.Client, url string, attempt int) (body []byte, wait time.Duration, err error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, xerrors.Errorf("unable to build request for %q: %w", url, err)
+	}
+	if u.apiKey != "" {
+		req.Header.Set("apiKey", u.apiKey)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		slog.Error("Response error. Try to get the entry again.", slog.String("error", err.Error()))
+		return nil, 0, nil
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		slog.Error("NVD rate limit. Wait to gain access.")
+		ra := u.retryAfter
+		// NVD returns the `Retry-After` header as 0.
+		// But if they start setting a non-zero value, we can use that duration.
+		if headerRetry := resp.Header.Get("Retry-After"); headerRetry != "0" {
+			if hRetry, err := time.ParseDuration(headerRetry); err == nil {
+				ra = hRetry
+			}
+		}
+		// NVD limits:
+		// Without API key: 5 requests / 30 seconds window
+		// With API key: 50 requests / 30 seconds window
+		return nil, ra, nil
+	case http.StatusServiceUnavailable, http.StatusRequestTimeout, http.StatusBadGateway, http.StatusGatewayTimeout, statusOriginTimeout:
+		slog.Error("NVD API is unstable. Try to fetch URL again.", slog.String("status_code", resp.Status))
+		// NVD API works unstable
+		return nil, time.Duration(attempt) * time.Second, nil
+	case http.StatusOK:
+		// Read the body here so that a transient error while reading the response
+		// (e.g. HTTP/2 `INTERNAL_ERROR` when NVD aborts the stream mid-body) is
+		// retried instead of failing the whole run.
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			slog.Error("Failed to read NVD response body. Try to fetch URL again.", slog.String("error", err.Error()))
+			return nil, time.Duration(attempt) * time.Second, nil
+		}
+		return body, 0, nil
+	default:
+		return nil, 0, xerrors.Errorf("unexpected status code: %s", resp.Status)
+	}
 }
 
 // TimeIntervals returns time intervals for NVD API

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -2,6 +2,7 @@ package nvd
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -153,29 +154,40 @@ func (u Updater) fetchEntry(url string) (Entry, error) {
 	return entry, nil
 }
 
+// errRetry signals fetchURL to retry. retryAfter is the server-mandated
+// minimum wait (rate limit); zero means apply the caller's backoff.
+type errRetry struct{ retryAfter time.Duration }
+
+func (errRetry) Error() string { return "retryable" }
+
 func (u Updater) fetchURL(url string) ([]byte, error) {
 	var c http.Client
 	for i := 0; i <= u.retry; i++ {
-		body, wait, err := u.doRequest(&c, url, i)
-		if err != nil {
+		body, err := u.doRequest(&c, url)
+		var re errRetry
+		switch {
+		case err == nil:
+			return body, nil
+		case errors.As(err, &re):
+			wait := re.retryAfter
+			if wait == 0 {
+				wait = time.Duration(i) * time.Second
+			}
+			time.Sleep(wait)
+		default:
 			return nil, err
 		}
-		// A nil body with a nil error means the request should be retried after `wait`.
-		if body != nil {
-			return body, nil
-		}
-		time.Sleep(wait)
 	}
 	return nil, xerrors.Errorf("unable to fetch url. Retry limit exceeded.")
 }
 
 // doRequest performs a single NVD request attempt and closes the response body
-// before returning. It returns the response body on success. A nil body with a
-// nil error means the request should be retried after waiting for `wait`.
-func (u Updater) doRequest(c *http.Client, url string, attempt int) (body []byte, wait time.Duration, err error) {
+// before returning. It returns the response body on success, or errRetry to
+// signal that fetchURL should retry the request.
+func (u Updater) doRequest(c *http.Client, url string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, 0, xerrors.Errorf("unable to build request for %q: %w", url, err)
+		return nil, xerrors.Errorf("unable to build request for %q: %w", url, err)
 	}
 	if u.apiKey != "" {
 		req.Header.Set("apiKey", u.apiKey)
@@ -184,7 +196,7 @@ func (u Updater) doRequest(c *http.Client, url string, attempt int) (body []byte
 	resp, err := c.Do(req)
 	if err != nil {
 		slog.Error("Response error. Try to get the entry again.", slog.String("error", err.Error()))
-		return nil, 0, nil
+		return nil, errRetry{}
 	}
 	defer resp.Body.Close()
 
@@ -202,23 +214,23 @@ func (u Updater) doRequest(c *http.Client, url string, attempt int) (body []byte
 		// NVD limits:
 		// Without API key: 5 requests / 30 seconds window
 		// With API key: 50 requests / 30 seconds window
-		return nil, ra, nil
+		return nil, errRetry{retryAfter: ra}
 	case http.StatusServiceUnavailable, http.StatusRequestTimeout, http.StatusBadGateway, http.StatusGatewayTimeout, statusOriginTimeout:
 		slog.Error("NVD API is unstable. Try to fetch URL again.", slog.String("status_code", resp.Status))
 		// NVD API works unstable
-		return nil, time.Duration(attempt) * time.Second, nil
+		return nil, errRetry{}
 	case http.StatusOK:
 		// Read the body here so that a transient error while reading the response
 		// (e.g. HTTP/2 `INTERNAL_ERROR` when NVD aborts the stream mid-body) is
 		// retried instead of failing the whole run.
-		body, err = io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			slog.Error("Failed to read NVD response body. Try to fetch URL again.", slog.String("error", err.Error()))
-			return nil, time.Duration(attempt) * time.Second, nil
+			return nil, errRetry{}
 		}
-		return body, 0, nil
+		return body, nil
 	default:
-		return nil, 0, xerrors.Errorf("unexpected status code: %s", resp.Status)
+		return nil, xerrors.Errorf("unexpected status code: %s", resp.Status)
 	}
 }
 

--- a/nvd/nvd_test.go
+++ b/nvd/nvd_test.go
@@ -86,6 +86,25 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
+			name:              "happy path 1 page after reconnect (524)",
+			maxResultsPerPage: 10,
+			wantApiKey:        "test_api_key",
+			retry:             1,
+			lastUpdatedTime:   time.Date(2023, 11, 26, 0, 0, 0, 0, time.UTC),
+			fakeTimeNow:       time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
+			respFiles: map[string]string{
+				"resultsPerPage=1&startIndex=0":  "testdata/fixtures/rootResp.json",
+				"resultsPerPage=10&startIndex=0": "testdata/fixtures/respPageFull.json",
+			},
+			respStatus: 524,
+			wantFiles: []string{
+				filepath.Join("api", "2020", "CVE-2020-8167.json"),
+				filepath.Join("api", "2021", "CVE-2021-22903.json"),
+				filepath.Join("api", "2021", "CVE-2021-3881.json"),
+				"last_updated.json",
+			},
+		},
+		{
 			name:              "happy path 2 pages",
 			maxResultsPerPage: 2,
 			lastUpdatedTime:   time.Date(2023, 11, 26, 0, 0, 0, 0, time.UTC),
@@ -151,6 +170,15 @@ func TestUpdate(t *testing.T) {
 			lastUpdatedTime:   time.Date(2023, 11, 26, 0, 0, 0, 0, time.UTC),
 			fakeTimeNow:       time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
 			respStatus:        504,
+			wantError:         "unable to fetch url",
+		},
+		{
+			name:              "524 response",
+			maxResultsPerPage: 10,
+			wantApiKey:        "test_api_key",
+			lastUpdatedTime:   time.Date(2023, 11, 26, 0, 0, 0, 0, time.UTC),
+			fakeTimeNow:       time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC),
+			respStatus:        524,
 			wantError:         "unable to fetch url",
 		},
 	}
@@ -226,6 +254,84 @@ func TestUpdate(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+// TestUpdate_RetryOnBodyReadError verifies that a transient error while reading
+// the response body (e.g. HTTP/2 `INTERNAL_ERROR` when NVD aborts the stream
+// mid-body) is retried instead of failing the whole run.
+func TestUpdate_RetryOnBodyReadError(t *testing.T) {
+	t.Setenv("NVD_API_KEY", "test_api_key")
+
+	tmpDir := t.TempDir()
+	savedVulnListDir := utils.VulnListDir()
+	utils.SetVulnListDir(tmpDir)
+	defer utils.SetVulnListDir(savedVulnListDir)
+
+	err := utils.SetLastUpdatedDate("api", time.Date(2023, 11, 26, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	respFiles := map[string]string{
+		"resultsPerPage=1&startIndex=0":  "testdata/fixtures/rootResp.json",
+		"resultsPerPage=10&startIndex=0": "testdata/fixtures/respPageFull.json",
+	}
+
+	var bodyBrokenOnce bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(resp http.ResponseWriter, req *http.Request) {
+		if !bodyBrokenOnce {
+			bodyBrokenOnce = true
+			// Declare a larger body than we actually send, then abort the
+			// connection so the client fails with an unexpected EOF on read.
+			hj, ok := resp.(http.Hijacker)
+			require.True(t, ok)
+			conn, _, err := hj.Hijack()
+			require.NoError(t, err)
+			_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1024\r\n\r\npartial"))
+			conn.Close()
+			return
+		}
+
+		var filePath string
+		for params, path := range respFiles {
+			if strings.Contains(req.URL.String(), params) {
+				filePath = path
+				break
+			}
+		}
+		if filePath == "" {
+			t.Errorf("response files doesn't exist for %q", req.URL.String())
+		}
+
+		b, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		_, err = resp.Write(b)
+		require.NoError(t, err)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	u := nvd.NewUpdater(nvd.WithBaseURL(ts.URL), nvd.WithMaxResultsPerPage(10),
+		nvd.WithRetry(1), nvd.WithLastModEndDate(time.Date(2023, 11, 28, 0, 0, 0, 0, time.UTC)),
+		nvd.WithRetryAfter(1*time.Second))
+	err = u.Update()
+	require.NoError(t, err)
+
+	wantFiles := []string{
+		filepath.Join("api", "2020", "CVE-2020-8167.json"),
+		filepath.Join("api", "2021", "CVE-2021-22903.json"),
+		filepath.Join("api", "2021", "CVE-2021-3881.json"),
+		"last_updated.json",
+	}
+	for _, wantFile := range wantFiles {
+		got, err := os.ReadFile(filepath.Join(tmpDir, wantFile))
+		require.NoError(t, err)
+
+		want, err := os.ReadFile(filepath.Join("testdata", "golden", wantFile))
+		require.NoError(t, err)
+
+		require.JSONEq(t, string(want), string(got))
 	}
 }
 


### PR DESCRIPTION
## Description

The NVD updater could fail an entire run on transient errors that were not covered by the retry loop:

- The response body was read **outside** `fetchURL`'s retry loop, so an HTTP/2 `INTERNAL_ERROR` (the stream aborted mid-body after a `200 OK`) was fatal instead of retried.
- Cloudflare's non-standard `524` (origin timeout) fell into the `default` branch and returned an "unexpected status code" error.

This PR reads the body inside the retry loop and adds `524` to the retryable statuses.
A single request attempt is extracted into a `doRequest` helper that closes the response body via `defer`.

## Context

On 2026-06-17 NVD rolled out a schema/metric expansion (SSVC data from CISA-ADP in addition to CVSS, plus an "affected" block per the CVE Record Format).
Every updated record received a new `Last Modified` date, which means a large share of the database was re-stamped in a single day.

As a result, the updater's per-day window started returning almost the whole database at once.
Compare a normal day to the affected day.

Successful run ([run 27657694905](https://github.com/aquasecurity/vuln-list-update/actions/runs/27657694905/job/81795312170#step:7:29)):

```
2026/06/17 00:39:15 INFO Fetched NVD entries total=169 start_index=0
```

Failing run ([run 27744143884](https://github.com/aquasecurity/vuln-list-update/actions/runs/27744143884/job/82078211053#step:7:28)):

```
2026/06/18 07:38:54 INFO Fetched NVD entries total=261624 start_index=0
```

Total number of records currently stored:

```
➜  api find . -type f | wc -l
  357760
```

So a single day's window covered `261624 / 357760 ≈ 73%` of all records — roughly 131 pages of 2000 entries.
Fetching that many pages takes 40–60 minutes, runs into the NVD rate limit, and eventually hits a transient server error (`503`, `524`, or an HTTP/2 `INTERNAL_ERROR`).
Before this change such a transient error failed the whole run and reverted it, so `lastUpdatedDate` never advanced and the next run pulled an even larger window — a self-sustaining loop.

This is not a regression on our side; it is the fallout of the NVD update.
Making the transient errors retryable lets a run survive the spike and finish, after which the window shrinks back to normal.

## Tests

- `TestUpdate` — added two `524` cases: a happy path that succeeds after one reconnect (`retry: 1`), and a sad path that exhausts retries (confirming `524` is now retried instead of returning "unexpected status code").
- `TestUpdate_RetryOnBodyReadError` — hijacks the connection to send a `200 OK` with a truncated body (declared `Content-Length` larger than the bytes sent, then closes the connection), forcing an `io.ReadAll` error after the status code, and verifies the next attempt succeeds.
