### PR TITLE
refactor(osv): allow multiple feed URLs per ecosystem

### DIFF
--- a/osv/osv.go
+++ b/osv/osv.go
@@ -34,7 +34,7 @@ type Database struct {
 
 // NewDatabase creates a new generic OSV database instance.
 // baseDir is the root directory where vulnerability data will be stored.
-// ecosystems maps ecosystem names to their configuration (storage directory and source URL).
+// ecosystems maps ecosystem names to their configuration (storage directory and source URLs).
 func NewDatabase(baseDir string, ecosystems map[string]Ecosystem) Database {
 	return Database{
 		baseDir:    baseDir,
@@ -45,53 +45,66 @@ func NewDatabase(baseDir string, ecosystems map[string]Ecosystem) Database {
 func (db *Database) Update() error {
 	ctx := context.Background()
 	for name, ecosystem := range db.ecosystems {
-		log.Printf("Updating OSV %s advisories", name)
-
-		tempDir, err := utils.DownloadToTempDir(ctx, ecosystem.URL)
-		if err != nil {
-			return xerrors.Errorf("failed to download %s: %w", ecosystem.URL, err)
+		if len(ecosystem.URLs) == 0 {
+			return xerrors.Errorf("ecosystem %s has no feed URLs", name)
 		}
 
-		// Remove the existing directory to delete files that have been removed from the source
+		// Remove the existing directory to delete files that have been removed from the source.
 		ecosystemDir := filepath.Join(db.baseDir, ecosystem.Dir)
 		log.Printf("[OSV] Removing %s directory", ecosystemDir)
-		if err = os.RemoveAll(ecosystemDir); err != nil {
+		if err := os.RemoveAll(ecosystemDir); err != nil {
 			return xerrors.Errorf("failed to remove %s directory: %w", name, err)
 		}
 
-		err = filepath.WalkDir(tempDir, func(path string, d fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			} else if d.IsDir() {
-				return nil
+		for _, url := range ecosystem.URLs {
+			log.Printf("Updating OSV %s advisories from %s", name, url)
+			if err := db.updateFromURL(ctx, ecosystemDir, url); err != nil {
+				return err
 			}
-			f, err := os.Open(path)
-			if err != nil {
-				return xerrors.Errorf("file open error (%s): %w", path, err)
-			}
-
-			var parsed OSV
-			if err = json.NewDecoder(f).Decode(&parsed); err != nil {
-				return xerrors.Errorf("unable to parse json %s: %w", path, err)
-			}
-
-			if len(parsed.Affected) == 0 {
-				log.Printf("[OSV] skipping %s: no affected packages", parsed.ID)
-				return nil
-			}
-
-			// Replace colons with slashes to avoid invalid directory names.
-			// e.g. Maven "groupId:artifactId" -> "groupId/artifactId"
-			pkgName := strings.ReplaceAll(parsed.Affected[0].Package.Name, ":", "/")
-			filePath := filepath.Join(db.baseDir, ecosystem.Dir, pkgName, fmt.Sprintf("%s.json", parsed.ID))
-			if err = utils.Write(filePath, parsed); err != nil {
-				return xerrors.Errorf("failed to write file: %w", err)
-			}
-			return nil
-		})
-		if err != nil {
-			return xerrors.Errorf("walk error: %w", err)
 		}
+	}
+	return nil
+}
+
+// updateFromURL downloads a single OSV feed and writes its advisories into ecosystemDir.
+func (db *Database) updateFromURL(ctx context.Context, ecosystemDir, url string) error {
+	tempDir, err := utils.DownloadToTempDir(ctx, url)
+	if err != nil {
+		return xerrors.Errorf("failed to download %s: %w", url, err)
+	}
+
+	err = filepath.WalkDir(tempDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		} else if d.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return xerrors.Errorf("file open error (%s): %w", path, err)
+		}
+
+		var parsed OSV
+		if err = json.NewDecoder(f).Decode(&parsed); err != nil {
+			return xerrors.Errorf("unable to parse json %s: %w", path, err)
+		}
+
+		if len(parsed.Affected) == 0 {
+			log.Printf("[OSV] skipping %s: no affected packages", parsed.ID)
+			return nil
+		}
+
+		// Replace colons with slashes to avoid invalid directory names.
+		// e.g. Maven "groupId:artifactId" -> "groupId/artifactId"
+		pkgName := strings.ReplaceAll(parsed.Affected[0].Package.Name, ":", "/")
+		filePath := filepath.Join(ecosystemDir, pkgName, fmt.Sprintf("%s.json", parsed.ID))
+		if err = utils.Write(filePath, parsed); err != nil {
+			return xerrors.Errorf("failed to write file: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("walk error: %w", err)
 	}
 	return nil
 }

--- a/osv/types.go
+++ b/osv/types.go
@@ -2,7 +2,9 @@ package osv
 
 type Ecosystem struct {
 	Dir string
-	URL string
+	// URLs lists every OSV feed whose advisories share the same Dir.
+	// e.g. Seal original and renamed packages.
+	URLs []string
 }
 
 type Affected struct {

--- a/osvdev/osvdev.go
+++ b/osvdev/osvdev.go
@@ -26,16 +26,16 @@ const (
 
 var defaultEcosystems = map[string]osv.Ecosystem{
 	"PyPI": {
-		Dir: "python",
-		URL: "https://osv-vulnerabilities.storage.googleapis.com/PyPI/all.zip",
+		Dir:  "python",
+		URLs: []string{"https://osv-vulnerabilities.storage.googleapis.com/PyPI/all.zip"},
 	},
 	"Go": {
-		Dir: "go",
-		URL: "https://osv-vulnerabilities.storage.googleapis.com/Go/all.zip",
+		Dir:  "go",
+		URLs: []string{"https://osv-vulnerabilities.storage.googleapis.com/Go/all.zip"},
 	},
 	"crates.io": {
-		Dir: "rust",
-		URL: "https://osv-vulnerabilities.storage.googleapis.com/crates.io/all.zip",
+		Dir:  "rust",
+		URLs: []string{"https://osv-vulnerabilities.storage.googleapis.com/crates.io/all.zip"},
 	},
 }
 

--- a/osvdev/osvdev_test.go
+++ b/osvdev/osvdev_test.go
@@ -98,8 +98,8 @@ func Test_Update(t *testing.T) {
 			ecosystems := make(map[string]osv.Ecosystem)
 			for name, dir := range tt.ecosystem {
 				ecosystems[name] = osv.Ecosystem{
-					Dir: dir,
-					URL: ts.URL + fmt.Sprintf("/%s/all.zip", name),
+					Dir:  dir,
+					URLs: []string{ts.URL + fmt.Sprintf("/%s/all.zip", name)},
 				}
 			}
 

--- a/seal/seal.go
+++ b/seal/seal.go
@@ -13,8 +13,8 @@ const (
 // Seal uses single archive for all ecosystems, so we use a single ecosystem and single dir.
 var ecosystems = map[string]osv.Ecosystem{
 	"seal": {
-		Dir: sealDir,
-		URL: securityTrackerURL,
+		Dir:  sealDir,
+		URLs: []string{securityTrackerURL},
 	},
 }
 

--- a/seal/seal_test.go
+++ b/seal/seal_test.go
@@ -62,8 +62,8 @@ func Test_Update(t *testing.T) {
 			// Create ecosystems map with test URL
 			ecosystems := map[string]osv.Ecosystem{
 				"seal": {
-					Dir: "",
-					URL: testURL,
+					Dir:  "",
+					URLs: []string{testURL},
 				},
 			}
 


### PR DESCRIPTION
## Description

Change `osv.Ecosystem.URL` (string) to `osv.Ecosystem.URLs` (`[]string`) so that several OSV feeds can be merged into a single output directory.

Some OSV sources expose more than one feed that Trivy reads from a single directory.
The concrete case is Seal, which publishes both an original-name feed and a renamed-name feed that must land side by side in `seal/`.
The current one-URL-per-ecosystem model cannot express this: `Update` removes the ecosystem directory once per source, so a second feed targeting the same directory would wipe the first.

This PR is the infrastructure-only part of that change.
It does not add any second feed yet — it only makes the generic `osv` layer capable of merging multiple feeds into one directory, so a follow-up can wire up Seal's second feed by adding a URL.

`Database.Update` now clears the ecosystem directory once, before iterating the feeds, then downloads and writes each feed into it in turn (extracted into `updateFromURL`).
Clearing once — rather than per feed — is what lets feeds accumulate instead of overwriting one another, while still dropping advisories that have been withdrawn from the source.

No behavioural change for existing sources: `osvdev` and `seal` each pass their single feed as a one-element slice, so the golden-file tests are unchanged.
