### PR TITLE
ci(update): free runner disk space to avoid "no space left on device"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,19 @@ jobs:
     env:
       VULN_LIST_DIR: "vuln-list"
     steps:
+      # Needs ~9GB for the vuln-list working tree plus at least ~9GB more for the sources,
+      # so free up disk space first to leave enough room.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null
+          df -h
+
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## Description

The scheduled `Update vuln-list repo` workflow has been failing with `No space left on device`, consistently dying on the `GitLab Advisory Database` step (and skipping every source after it).

The cause isn't a single large source — the individual downloads are small, and the git-based sources are cloned shallowly (`--depth 1`), so we don't pull full history. The real pressure is the `vuln-list` repository itself: it is checked out on the runner in full, and its working tree is now ~9GB. On the 2-core runner that leaves only a few GB free, and the source caches that accumulate across steps (the shallow `ubuntu` clone alone is ~2GB) eventually fill the disk. It happens to tip over on the `glad` step simply because it sits in the middle of the list.

Breakdown of the checked-out `vuln-list` working tree (largest directories):

| Directory | On-disk size |
|---|---:|
| ubuntu | ~3.1 GB |
| cvrf (SUSE) | ~2.1 GB |
| nvd | ~1.1 GB |
| oval (Oracle) | ~140 MB |
| rocky | ~134 MB |
| openeuler | ~132 MB |
| rootio | ~100 MB |
| osv | ~84 MB |
| ghsa | ~78 MB |
| alma | ~67 MB |
| glad | ~61 MB |
| amazon | ~43 MB |
| other (~15 dirs) | < 30 MB each |
| **Total** | **~9 GB** |

This adds a `Free disk space` step at the start of the job, mirroring the one already used in `redhat.yml`. It removes preinstalled toolchains we don't need (dotnet, Android SDK, GHC, Boost, CodeQL) and prunes Docker images, freeing ~20GB before the sources run.

## CI/CD errors:
- https://github.com/aquasecurity/vuln-list-update/actions/runs/28357275201/job/84003174313
- https://github.com/aquasecurity/vuln-list-update/actions/runs/28331935581
