### PR TITLE
ci: replace Microsoft Teams failure alerts with Slack

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -49,11 +49,11 @@ jobs:
         repository: ${{ env.VULN_LIST_DIR }}
         commit-message: "Debian Security Bug Tracker"
 
-    - name: Microsoft Teams Notification
-      uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
+    - name: Slack Notification
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       if: failure()
       with:
-        webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-        needs: ${{ toJson(needs) }}
-        job: ${{ toJson(job) }}
-        steps: ${{ toJson(steps) }}
+        webhook: ${{ secrets.TRIVY_SLACK_WEBHOOK }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: ":x: *${{ github.workflow }}* workflow failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -49,11 +49,11 @@ jobs:
         repository: ${{ env.VULN_LIST_DIR }}
         commit-message: "NVD"
 
-    - name: Microsoft Teams Notification
-      uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
+    - name: Slack Notification
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       if: failure()
       with:
-        webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-        needs: ${{ toJson(needs) }}
-        job: ${{ toJson(job) }}
-        steps: ${{ toJson(steps) }}
+        webhook: ${{ secrets.TRIVY_SLACK_WEBHOOK }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: ":x: *${{ github.workflow }}* workflow failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -83,11 +83,11 @@ jobs:
         repository: ${{ env.VULN_LIST_DIR }}
         commit-message: "Red Hat Security Data API"
 
-    - name: Microsoft Teams Notification
-      uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
+    - name: Slack Notification
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       if: failure()
       with:
-        webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-        needs: ${{ toJson(needs) }}
-        job: ${{ toJson(job) }}
-        steps: ${{ toJson(steps) }}
+        webhook: ${{ secrets.TRIVY_SLACK_WEBHOOK }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: ":x: *${{ github.workflow }}* workflow failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -269,11 +269,11 @@ jobs:
           repository: ${{ env.VULN_LIST_DIR }}
           commit-message: "EOL dates"
 
-      - name: Microsoft Teams Notification
-        uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: failure()
         with:
-          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-          needs: ${{ toJson(needs) }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
+          webhook: ${{ secrets.TRIVY_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":x: *${{ github.workflow }}* workflow failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"


### PR DESCRIPTION
Migrate the CI failure notifications to Slack.

## What changed

Replace the `Skitionek/notify-microsoft-teams` step with the official `slackapi/slack-github-action` (pinned by commit SHA) in the `nvd`, `redhat`, `debian` and `update` workflows.
Each alert fires on `failure()` and posts the failing workflow name and a link to the run via an incoming webhook.

## Ops follow-up

A new `TRIVY_SLACK_WEBHOOK` repository secret must be added (Slack incoming webhook URL).
The old `TRIVY_MSTEAMS_WEBHOOK` secret can be removed once Slack alerts are confirmed working.

## Testing

Verified on a fork branch — the `nvd` and `update` workflows were forced to fail, and the Slack notification step posted successfully to a test channel:

- [`Update vuln-list-nvd repo` run](https://github.com/DmitriyLewen/vuln-list-update/actions/runs/28660067899)
- [`Update vuln-list repo` run](https://github.com/DmitriyLewen/vuln-list-update/actions/runs/28660069082)

_Slack alerts in the test channel:_
<img width="1202" height="238" alt="изображение" src="https://github.com/user-attachments/assets/bfa07b19-8a57-4831-bf54-ab56023a08ad" />



